### PR TITLE
모장 매핑 기반으로 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,27 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import net.md_5.specialsource.Jar
+import net.md_5.specialsource.JarMapping
+import net.md_5.specialsource.JarRemapper
+import net.md_5.specialsource.provider.JarProvider
+import net.md_5.specialsource.provider.JointProvider
+import java.io.File
 import java.io.OutputStream.nullOutputStream
+import org.gradle.jvm.tasks.Jar as GradleJar
 
 plugins {
     kotlin("jvm") version "1.5.20"
     id("com.github.johnrengelman.shadow") version "7.0.0"
     `maven-publish`
+}
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("net.md-5:SpecialSource:1.10.0")
+    }
 }
 
 java {
@@ -35,7 +52,7 @@ allprojects {
         testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
         testImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.0")
         testImplementation("org.mockito:mockito-core:3.6.28")
-        testImplementation("org.spigotmc:spigot:1.17-R0.1-SNAPSHOT")
+        testImplementation("org.spigotmc:spigot:1.17-R0.1-SNAPSHOT:remapped-mojang")
     }
 
     tasks {
@@ -64,9 +81,59 @@ subprojects {
             testImplementation("io.papermc.paper:paper-api:1.17-R0.1-SNAPSHOT")
         }
     } else {
+        configurations {
+            create("mojangMapping")
+            create("spigotMapping")
+        }
+
         //setup nms
         dependencies {
             implementation(project(":api"))
+        }
+
+        tasks {
+            jar {
+                doLast {
+                    val archiveFile = archiveFile.get().asFile
+                    val mojangOutput = File(archiveFile.parentFile, "remapped-mojang.jar")
+                    val spigotOutput = File(archiveFile.parentFile, "remapped-spigot.jar")
+
+                    val mojangMapping = configurations.named("mojangMapping").get().firstOrNull()
+                    val spigotMapping = configurations.named("spigotMapping").get().firstOrNull()
+
+                    if (mojangMapping != null && spigotMapping != null) {
+                        var inputJar = Jar.init(archiveFile)
+                        val mojang = JarMapping()
+                        mojang.loadMappings(mojangMapping.canonicalPath, true, false, null, null)
+
+                        val mojangProvider = JointProvider()
+                        mojangProvider.add(JarProvider(inputJar))
+                        mojang.setFallbackInheritanceProvider(mojangProvider)
+
+                        val mojangRemapper = JarRemapper(mojang)
+                        mojangRemapper.remapJar(inputJar, mojangOutput)
+                        inputJar.close()
+
+                        inputJar = Jar.init(mojangOutput)
+                        val spigot = JarMapping()
+                        spigot.loadMappings(spigotMapping)
+
+                        val spigotProvider = JointProvider()
+                        spigotProvider.add(JarProvider(inputJar))
+                        spigot.setFallbackInheritanceProvider(spigotProvider)
+
+                        val spigotRemapper = JarRemapper(spigot)
+                        spigotRemapper.remapJar(inputJar, spigotOutput)
+                        inputJar.close()
+
+                        archiveFile.writeBytes(spigotOutput.readBytes())
+                        mojangOutput.delete()
+                        spigotOutput.delete()
+                    } else {
+                        logger.warn("Mojang and Spigot mapping should be specified for ${path.drop(1).takeWhile { it != ':' }}.")
+                    }
+                }
+            }
         }
     }
 }
@@ -83,7 +150,7 @@ tasks {
             from(subproject.sourceSets["main"].output)
         }
     }
-    create<Jar>("sourcesJar") {
+    create<GradleJar>("sourcesJar") {
         archiveClassifier.set("sources")
         for (subproject in subprojects) {
             from(subproject.sourceSets["main"].allSource)
@@ -142,7 +209,7 @@ tasks {
                     javaexec {
                         workingDir(buildtoolsDir)
                         mainClass.set("-jar")
-                        args = listOf("./${buildtools.name}", "--rev", v, "--disable-java-check")
+                        args = listOf("./${buildtools.name}", "--rev", v, "--disable-java-check", "--remapped")
                         // Silent
                         standardOutput = nullOutputStream()
                         errorOutput = nullOutputStream()

--- a/v1_17_R1/build.gradle.kts
+++ b/v1_17_R1/build.gradle.kts
@@ -1,3 +1,5 @@
 dependencies {
-    compileOnly("org.spigotmc:spigot:1.17-R0.1-SNAPSHOT")
+    compileOnly("org.spigotmc:spigot:1.17-R0.1-SNAPSHOT:remapped-mojang")
+    mojangMapping("org.spigotmc:minecraft-server:1.17-R0.1-SNAPSHOT:maps-mojang@txt")
+    spigotMapping("org.spigotmc:minecraft-server:1.17-R0.1-SNAPSHOT:maps-spigot@csrg")
 }

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSEntityTypes.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSEntityTypes.kt
@@ -16,8 +16,8 @@
 
 package io.github.monun.tap.v1_17_R1.fake
 
-import net.minecraft.core.IRegistry
-import net.minecraft.world.entity.EntityTypes
+import net.minecraft.core.Registry
+import net.minecraft.world.entity.EntityType
 import org.bukkit.Bukkit
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer
 import java.util.*
@@ -28,13 +28,13 @@ import org.bukkit.entity.Entity as BukkitEntity
  */
 internal object NMSEntityTypes {
 
-    private val ENTITIES: MutableMap<Class<out BukkitEntity>, EntityTypes<*>> = HashMap()
+    private val ENTITIES: MutableMap<Class<out BukkitEntity>, EntityType<*>> = HashMap()
 
     init {
-        val world = (Bukkit.getServer() as CraftServer).server.worlds.first()
+        val world = (Bukkit.getServer() as CraftServer).server.allLevels.first()
 
-        IRegistry.Y.forEach { type ->
-            type.a(world)?.let { entity ->
+        Registry.ENTITY_TYPE.forEach { type ->
+            type.create(world)?.let { entity ->
                 val bukkitClass = entity.bukkitEntity.javaClass
                 val interfaces = bukkitClass.interfaces
 
@@ -49,7 +49,7 @@ internal object NMSEntityTypes {
         }
     }
 
-    fun findType(bukkitClass: Class<out BukkitEntity>): EntityTypes<*>? {
+    fun findType(bukkitClass: Class<out BukkitEntity>): EntityType<*>? {
         return ENTITIES[bukkitClass]
     }
 

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSFakeSupport.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSFakeSupport.kt
@@ -18,8 +18,8 @@ package io.github.monun.tap.v1_17_R1.fake
 
 import com.comphenix.protocol.events.PacketContainer
 import io.github.monun.tap.fake.FakeSupport
-import net.minecraft.core.IRegistry
-import net.minecraft.world.entity.item.EntityFallingBlock
+import net.minecraft.core.Registry
+import net.minecraft.world.entity.item.FallingBlockEntity
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.World
@@ -38,14 +38,14 @@ class NMSFakeSupport : FakeSupport {
     override fun getNetworkId(entity: Entity): Int {
         entity as CraftEntity
 
-        return IRegistry.Y.getId(entity.handle.entityType)
+        return Registry.ENTITY_TYPE.getId(entity.handle.type)
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : Entity> createEntity(entityClass: Class<out Entity>, world: World): T? {
         return NMSEntityTypes.findType(entityClass)?.run {
             val nmsWorld = (world as CraftWorld).handle
-            this.a(nmsWorld)?.bukkitEntity as T
+            this.create(nmsWorld)?.bukkitEntity as T
         }
     }
 
@@ -71,39 +71,39 @@ class NMSFakeSupport : FakeSupport {
         val nmsEntity = entity.handle
 
         loc.run {
-            nmsEntity.t = (world as CraftWorld).handle
-            nmsEntity.setPositionRotation(x, y, z, yaw, pitch)
+            nmsEntity.level = (world as CraftWorld).handle
+            nmsEntity.moveTo(x, y, z, yaw, pitch)
         }
     }
 
     override fun getMountedYOffset(entity: Entity): Double {
         entity as CraftEntity
 
-        return entity.handle.bl()
+        return entity.handle.passengersRidingOffset
     }
 
     override fun getYOffset(entity: Entity): Double {
         entity as CraftEntity
 
-        return entity.handle.bk()
+        return entity.handle.myRidingOffset
     }
 
     override fun createSpawnPacket(entity: Entity): PacketContainer{
         entity as CraftEntity
 
-        return PacketContainer.fromPacket(entity.handle.packet)
+        return PacketContainer.fromPacket(entity.handle.addEntityPacket)
     }
 
     override fun createFallingBlock(blockData: BlockData): FallingBlock {
         val entity =
-            EntityFallingBlock(
+            FallingBlockEntity(
                 (Bukkit.getWorlds().first() as CraftWorld).handle,
                 0.0,
                 0.0,
                 0.0,
                 (blockData as CraftBlockData).state
             )
-        entity.R = 1
+        entity.tickCount = 1
 
         return entity.bukkitEntity as FallingBlock
     }

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/item/NMSItemSupport.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/item/NMSItemSupport.kt
@@ -17,9 +17,9 @@
 package io.github.monun.tap.v1_17_R1.item
 
 import io.github.monun.tap.item.ItemSupport
-import net.minecraft.nbt.NBTTagCompound
+import net.minecraft.nbt.CompoundTag
 import net.minecraft.world.damagesource.DamageSource
-import net.minecraft.world.entity.player.PlayerInventory
+import net.minecraft.world.entity.player.Inventory
 import net.minecraft.world.item.ItemStack
 import org.bukkit.craftbukkit.v1_17_R1.CraftEquipmentSlot
 import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer
@@ -32,13 +32,13 @@ import org.bukkit.inventory.PlayerInventory as BukkitPlayerInventory
 class NMSItemSupport : ItemSupport {
     override fun saveToJsonString(item: BukkitItemStack): String {
         val nmsItem = CraftItemStack.asNMSCopy(item)
-        return nmsItem.save(NBTTagCompound()).toString()
+        return nmsItem.save(CompoundTag()).toString()
     }
 
     override fun damageArmor(playerInventory: BukkitPlayerInventory, attackDamage: Double) {
         val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
 
-        nmsInventory.a(DamageSource.d, attackDamage.toFloat(), PlayerInventory.f)
+        nmsInventory.hurtArmor(DamageSource.LAVA, attackDamage.toFloat(), Inventory.ALL_ARMOR_SLOTS)
     }
 
     override fun damageSlot(playerInventory: BukkitPlayerInventory, slot: EquipmentSlot, damage: Int) {
@@ -47,17 +47,17 @@ class NMSItemSupport : ItemSupport {
         val nmsItem = nmsInventory.getItem(slot)
 
         if (!nmsItem.isEmpty) {
-            nmsItem.damage(damage, (playerInventory.holder as CraftPlayer).handle) { player ->
-                player.broadcastItemBreak(nmsSlot)
+            nmsItem.hurtAndBreak(damage, (playerInventory.holder as CraftPlayer).handle) { player ->
+                player.broadcastBreakEvent(nmsSlot)
             }
         }
     }
 }
 
-internal fun PlayerInventory.getItem(slot: EquipmentSlot): ItemStack {
+internal fun Inventory.getItem(slot: EquipmentSlot): ItemStack {
     return when (slot) {
-        EquipmentSlot.HAND -> itemInHand
-        EquipmentSlot.OFF_HAND -> j[0]
+        EquipmentSlot.HAND -> getSelected()
+        EquipmentSlot.OFF_HAND -> offhand[0]
         EquipmentSlot.FEET -> armorContents[0]
         EquipmentSlot.LEGS -> armorContents[1]
         EquipmentSlot.CHEST -> armorContents[2]


### PR DESCRIPTION
## 변경 사항

 - v1_17_R1/build.gradle.kts 처럼 구성하여 사용
 - md_5 님의 SpecialSource 라이브러리를 이용한 모장 -> 난독화 -> 스피곳 리매핑
   (모장 매핑은 개발용으로만 사용할 수 있습니다)
 - setupWorkspace 작업에 remapped 플래그 추가
 
 ---

## 주의 사항

BuildTools 의 버그로 pom 파일을 직접 수정해야 빌드가 됩니다 ㅠㅠ
`~/.m2/repository/org/spigotmc/minecraft-server/1.17-R0.1-SNAPSHOT/minecraft-server-1.17-R0.1-SNAPSHOT.pom`
해당 파일의 8번째 줄 (packaging 부분) 을 주석처리 혹은 제거 후 프로젝트 빌드가 가능합니다. Spigot Stash 에 Issue 남겨놓도록 하겠습니다.

---

추후에 PaperMC 측에서 더 나은 구현이 나오기를 기대해봅니다...!