### PR TITLE
모장 매핑 사용에 따른 디버그 불편 최소화 (모장 매핑을 사용하는 Paper 구성, ProtocolLib 의존성 제거)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ libs/
 
 # Debug
 .debug/
+
+# Paper submodule
+.paper/

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ build/
 # Avoid ignoring Jitpack jar file (.jar files are usually ignored)
 !jitpack.jar
 
-# External Library
-libs/
-
 # Buildtools
 .buildtools/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".paper"]
+	path = .paper
+	url = https://github.com/PaperMC/Paper.git

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 ### 환경
 * JDK 16
 * Kotlin 1.5.20
-* ProtocolLib 4.7.0
 * Paper 1.17
  
 ### Gradle
@@ -35,7 +34,6 @@ dependencies {
 ``` 
 
 ### NOTE
-* Tap의 Packet 패키지를 이용하기 위해선 [ProtocolLib](https://github.com/dmulloy2/ProtocolLib/releases) 을 필요로 합니다.
 * Tap의 개발환경 구축을 위해선 spigot 1.17 이 필요합니다. [BuildTools](https://www.spigotmc.org/wiki/buildtools/) 를 이용해 로컬 메이븐 저장소에 spigot을 배포하세요.
 * `./gradlew setupWorkspace` 명령으로 간단하게 배포할수있습니다.
   

--- a/api/src/main/kotlin/io/github/monun/tap/fake/FakeSupport.kt
+++ b/api/src/main/kotlin/io/github/monun/tap/fake/FakeSupport.kt
@@ -16,8 +16,8 @@
 
 package io.github.monun.tap.fake
 
-import com.comphenix.protocol.events.PacketContainer
 import io.github.monun.tap.loader.LibraryLoader
+import io.github.monun.tap.protocol.PacketContainer
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.World

--- a/api/src/main/kotlin/io/github/monun/tap/fake/internal/FakeTracker.kt
+++ b/api/src/main/kotlin/io/github/monun/tap/fake/internal/FakeTracker.kt
@@ -16,7 +16,7 @@
 
 package io.github.monun.tap.fake.internal
 
-import com.comphenix.protocol.events.PacketContainer
+import io.github.monun.tap.protocol.PacketContainer
 import io.github.monun.tap.protocol.sendServerPacket
 import io.github.monun.tap.ref.UpstreamReference
 import org.bukkit.entity.Player

--- a/api/src/main/kotlin/io/github/monun/tap/protocol/PacketContainer.kt
+++ b/api/src/main/kotlin/io/github/monun/tap/protocol/PacketContainer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Monun
+ *
+ * Licensed under the General Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://opensource.org/licenses/gpl-3.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.github.monun.tap.protocol
+
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.entity.Player
+
+interface PacketContainer {
+    fun sendTo(player: Player)
+
+    fun sendTo(players: Iterable<Player>) {
+        players.forEach(::sendTo)
+    }
+
+    fun sendAll()
+
+    fun sendNearBy(world: World, x: Double, y: Double, z: Double, radius: Double)
+
+    fun sendNearBy(loc: Location, radius: Double) {
+        sendNearBy(loc.world, loc.x, loc.y, loc.z, radius)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ import net.md_5.specialsource.provider.JarProvider
 import net.md_5.specialsource.provider.JointProvider
 import org.apache.tools.ant.taskdefs.condition.Os
 import java.io.OutputStream.nullOutputStream
+
 import org.gradle.jvm.tasks.Jar as GradleJar
 
 plugins {
@@ -45,8 +46,6 @@ allprojects {
     dependencies {
         compileOnly(kotlin("stdlib"))
         compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
-        compileOnly("com.comphenix.protocol:ProtocolLib:4.7.0-SNAPSHOT")
-//        compileOnly(rootProject.fileTree("dir" to "libs", "include" to "*.jar"))
 
         implementation("org.mariuszgromada.math:MathParser.org-mXparser:4.4.2")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import de.undercouch.gradle.tasks.download.Download
 import net.md_5.specialsource.Jar
 import net.md_5.specialsource.JarMapping
 import net.md_5.specialsource.JarRemapper
 import net.md_5.specialsource.provider.JarProvider
 import net.md_5.specialsource.provider.JointProvider
-import java.io.File
 import java.io.OutputStream.nullOutputStream
 import org.gradle.jvm.tasks.Jar as GradleJar
 
@@ -94,43 +94,39 @@ subprojects {
         tasks {
             jar {
                 doLast {
+                    fun remap(jarFile: File, outputFile: File, mappingFile: File, reversed: Boolean = false) {
+                        val inputJar = Jar.init(jarFile)
+
+                        val mapping = JarMapping()
+                        mapping.loadMappings(mappingFile.canonicalPath, reversed, false, null, null)
+
+                        val provider = JointProvider()
+                        provider.add(JarProvider(inputJar))
+                        mapping.setFallbackInheritanceProvider(provider)
+
+                        val mapper = JarRemapper(mapping)
+                        mapper.remapJar(inputJar, outputFile)
+                        inputJar.close()
+                    }
+
                     val archiveFile = archiveFile.get().asFile
-                    val mojangOutput = File(archiveFile.parentFile, "remapped-mojang.jar")
+
+                    val obfOutput = File(archiveFile.parentFile, "remapped-obf.jar")
                     val spigotOutput = File(archiveFile.parentFile, "remapped-spigot.jar")
 
                     val mojangMapping = configurations.named("mojangMapping").get().firstOrNull()
                     val spigotMapping = configurations.named("spigotMapping").get().firstOrNull()
 
                     if (mojangMapping != null && spigotMapping != null) {
-                        var inputJar = Jar.init(archiveFile)
-                        val mojang = JarMapping()
-                        mojang.loadMappings(mojangMapping.canonicalPath, true, false, null, null)
+                        remap(archiveFile, obfOutput, mojangMapping, true)
+                        remap(obfOutput, spigotOutput, spigotMapping)
 
-                        val mojangProvider = JointProvider()
-                        mojangProvider.add(JarProvider(inputJar))
-                        mojang.setFallbackInheritanceProvider(mojangProvider)
-
-                        val mojangRemapper = JarRemapper(mojang)
-                        mojangRemapper.remapJar(inputJar, mojangOutput)
-                        inputJar.close()
-
-                        inputJar = Jar.init(mojangOutput)
-                        val spigot = JarMapping()
-                        spigot.loadMappings(spigotMapping)
-
-                        val spigotProvider = JointProvider()
-                        spigotProvider.add(JarProvider(inputJar))
-                        spigot.setFallbackInheritanceProvider(spigotProvider)
-
-                        val spigotRemapper = JarRemapper(spigot)
-                        spigotRemapper.remapJar(inputJar, spigotOutput)
-                        inputJar.close()
-
-                        archiveFile.writeBytes(spigotOutput.readBytes())
-                        mojangOutput.delete()
+                        spigotOutput.copyTo(archiveFile, true)
+                        obfOutput.delete()
                         spigotOutput.delete()
                     } else {
-                        logger.warn("Mojang and Spigot mapping should be specified for ${path.drop(1).takeWhile { it != ':' }}.")
+                        logger.warn("Mojang and Spigot mapping should be specified for ${
+                            path.drop(1).takeWhile { it != ':' }}.")
                     }
                 }
             }
@@ -196,7 +192,7 @@ tasks {
                 repos.find { it.name.startsWith(version) }?.also { println("Skip downloading spigot-$version") } == null
             }.also { if (it.isEmpty()) return@doLast }
 
-            val download by registering(de.undercouch.gradle.tasks.download.Download::class) {
+            val download by registering(Download::class) {
                 src("https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar")
                 dest(buildtools)
             }

--- a/debug.sh
+++ b/debug.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-./gradlew clean debugJar
+./gradlew clean setupDebugServer
+# To Update Paper:
+# ./gradlew clean setupDebugServer -PupdatePaper
 
-server='https://papermc.io/api/v1/paper/1.17/latest/download'
 plugins=(
   'https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/target/ProtocolLib.jar'
 )
@@ -26,12 +27,12 @@ cd "$server_folder"
 
 if [ ! -f "$server_config" ]; then
     cat << EOF > $server_config
-server=$server
+server="."
 debug=true
 debug_port=5005
 backup=false
 restart=false
-memory=16
+memory=2
 plugins=(
 EOF
     for plugin in "${plugins[@]}"

--- a/debug.sh
+++ b/debug.sh
@@ -5,7 +5,6 @@
 # ./gradlew clean setupDebugServer -PupdatePaper
 
 plugins=(
-  'https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/artifact/target/ProtocolLib.jar'
 )
 
 script=$(basename "$0")

--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -1,6 +1,5 @@
 name: $pluginName
 main: $pluginMain
-depend: [ ProtocolLib ]
 api-version: '1.13'
 version: $version
 libraries:

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSEntityTypes.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSEntityTypes.kt
@@ -17,6 +17,7 @@
 package io.github.monun.tap.v1_17_R1.fake
 
 import net.minecraft.core.Registry
+import net.minecraft.server.MinecraftServer
 import net.minecraft.world.entity.EntityType
 import org.bukkit.Bukkit
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer
@@ -28,13 +29,14 @@ import org.bukkit.entity.Entity as BukkitEntity
  */
 internal object NMSEntityTypes {
 
-    private val ENTITIES: MutableMap<Class<out BukkitEntity>, EntityType<*>> = HashMap()
+    private val ENTITIES = HashMap<Class<out BukkitEntity>, EntityType<*>>()
 
     init {
-        val world = (Bukkit.getServer() as CraftServer).server.allLevels.first()
+        val server: MinecraftServer = (Bukkit.getServer() as CraftServer).server
+        val level = server.allLevels.first()
 
         Registry.ENTITY_TYPE.forEach { type ->
-            type.create(world)?.let { entity ->
+            type.create(level)?.let { entity ->
                 val bukkitClass = entity.bukkitEntity.javaClass
                 val interfaces = bukkitClass.interfaces
 
@@ -49,8 +51,8 @@ internal object NMSEntityTypes {
         }
     }
 
+    @JvmStatic
     fun findType(bukkitClass: Class<out BukkitEntity>): EntityType<*>? {
         return ENTITIES[bukkitClass]
     }
-
 }

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSFakeSupport.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/fake/NMSFakeSupport.kt
@@ -16,8 +16,8 @@
 
 package io.github.monun.tap.v1_17_R1.fake
 
-import com.comphenix.protocol.events.PacketContainer
 import io.github.monun.tap.fake.FakeSupport
+import io.github.monun.tap.v1_17_R1.protocol.NMSPacketContainer
 import net.minecraft.core.Registry
 import net.minecraft.world.entity.item.FallingBlockEntity
 import org.bukkit.Bukkit
@@ -88,10 +88,10 @@ class NMSFakeSupport : FakeSupport {
         return entity.handle.myRidingOffset
     }
 
-    override fun createSpawnPacket(entity: Entity): PacketContainer{
+    override fun createSpawnPacket(entity: Entity): NMSPacketContainer {
         entity as CraftEntity
 
-        return PacketContainer.fromPacket(entity.handle.addEntityPacket)
+        return NMSPacketContainer(entity.handle.addEntityPacket)
     }
 
     override fun createFallingBlock(blockData: BlockData): FallingBlock {

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketContainer.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketContainer.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Monun
+ *
+ * Licensed under the General Public License, Version 3.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://opensource.org/licenses/gpl-3.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.github.monun.tap.v1_17_R1.protocol
+
+import io.github.monun.tap.protocol.PacketContainer
+import net.minecraft.network.protocol.Packet
+import net.minecraft.server.level.ServerPlayer
+import org.bukkit.Bukkit
+import org.bukkit.World
+import org.bukkit.craftbukkit.v1_17_R1.CraftServer
+import org.bukkit.craftbukkit.v1_17_R1.CraftWorld
+import org.bukkit.craftbukkit.v1_17_R1.entity.CraftPlayer
+import org.bukkit.entity.Player
+
+
+class NMSPacketContainer(private val packet: Packet<*>) : PacketContainer {
+    override fun sendTo(player: Player) {
+        player as CraftPlayer
+
+        sendTo(player.handle)
+    }
+
+    override fun sendAll() {
+        SERVER.players.forEach { player ->
+            sendTo(player)
+        }
+    }
+
+    override fun sendNearBy(world: World, x: Double, y: Double, z: Double, radius: Double) {
+        val dimension = (world as CraftWorld).handle.dimension()
+        val squareRadius = radius * radius
+
+        for (player in SERVER.players) {
+            if (player.level.dimension() == dimension) {
+                val dx = x - player.x
+                val dy = y - player.y
+                val dz = z - player.z
+
+                if (dx * dx + dy * dy + dz * dz < squareRadius) {
+                    sendTo(player)
+                }
+            }
+        }
+    }
+
+    private fun sendTo(player: ServerPlayer) {
+        player.connection?.send(packet)
+    }
+
+    companion object {
+        private val SERVER = (Bukkit.getServer() as CraftServer).handle
+    }
+}

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketContainer.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketContainer.kt
@@ -58,7 +58,7 @@ class NMSPacketContainer(private val packet: Packet<*>) : PacketContainer {
     }
 
     private fun sendTo(player: ServerPlayer) {
-        player.connection?.send(packet)
+        player.connection?.send(packet, null)
     }
 
     companion object {


### PR DESCRIPTION
#6 PR로 적용된 모장 매핑 때문에 디버깅이 제대로 되지 않는 문제를 해결하기 위해 아래와 같은 사항들을 적용하였습니다.
 - 모장 매핑을 사용하는 Paper jar을 생성하는 Task 제작
   - `setupDebugServer` 를 사용하여 .debug 폴더에 paper jar을 생성할 수 있습니다.
   - `setupDebugServer -PupdatePaper` 를 사용하여 [PaperMC/Paper](https://github.com/PaperMC/Paper) 의 마스터 브랜치에서 변경 사항을 가져온 뒤, paper jar을 생성할 수 있습니다.
 - 모장 매핑을 지원하지 않는 ProtocolLib 대신, `net.minecraft.network.protocol.game` 패키지의 Clientbound 패킷을 사용하여 패킷을 구성합니다.
   - 추후 마인크래프트 버전이 올라갈 경우 ProtocolLib 업데이트를 기다릴 필요 없이 Tap 업데이트를 진행할 수 있는 이점이 있을 걸로 예상됩니다.
   - ProtocolLib의 Reflection 사용보다는 더 나은 퍼포먼스를 보여줄 것으로 예상됩니다.
 - #6 PR에서 미처 확인하지 못했던 매핑 오류를 해결하였습니다.