### PR TITLE
Windows 환경에서 debug.sh 실행하며 발생한 문제 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,40 +94,42 @@ subprojects {
         tasks {
             jar {
                 doLast {
-                    fun remap(jarFile: File, outputFile: File, mappingFile: File, reversed: Boolean = false) {
-                        val inputJar = Jar.init(jarFile)
+                    if (!gradle.taskGraph.hasTask(":debugJar")) {
+                        fun remap(jarFile: File, outputFile: File, mappingFile: File, reversed: Boolean = false) {
+                            val inputJar = Jar.init(jarFile)
 
-                        val mapping = JarMapping()
-                        mapping.loadMappings(mappingFile.canonicalPath, reversed, false, null, null)
+                            val mapping = JarMapping()
+                            mapping.loadMappings(mappingFile.canonicalPath, reversed, false, null, null)
 
-                        val provider = JointProvider()
-                        provider.add(JarProvider(inputJar))
-                        mapping.setFallbackInheritanceProvider(provider)
+                            val provider = JointProvider()
+                            provider.add(JarProvider(inputJar))
+                            mapping.setFallbackInheritanceProvider(provider)
 
-                        val mapper = JarRemapper(mapping)
-                        mapper.remapJar(inputJar, outputFile)
-                        inputJar.close()
-                    }
+                            val mapper = JarRemapper(mapping)
+                            mapper.remapJar(inputJar, outputFile)
+                            inputJar.close()
+                        }
 
-                    val archiveFile = archiveFile.get().asFile
+                        val archiveFile = archiveFile.get().asFile
 
-                    val obfOutput = File(archiveFile.parentFile, "remapped-obf.jar")
-                    val spigotOutput = File(archiveFile.parentFile, "remapped-spigot.jar")
+                        val obfOutput = File(archiveFile.parentFile, "remapped-obf.jar")
+                        val spigotOutput = File(archiveFile.parentFile, "remapped-spigot.jar")
 
-                    val mojangMapping = configurations.named("mojangMapping").get().firstOrNull()
-                    val spigotMapping = configurations.named("spigotMapping").get().firstOrNull()
+                        val mojangMapping = configurations.named("mojangMapping").get().firstOrNull()
+                        val spigotMapping = configurations.named("spigotMapping").get().firstOrNull()
 
-                    if (mojangMapping != null && spigotMapping != null) {
-                        remap(archiveFile, obfOutput, mojangMapping, true)
-                        remap(obfOutput, spigotOutput, spigotMapping)
+                        if (mojangMapping != null && spigotMapping != null) {
+                            remap(archiveFile, obfOutput, mojangMapping, true)
+                            remap(obfOutput, spigotOutput, spigotMapping)
 
-                        spigotOutput.copyTo(archiveFile, true)
-                        obfOutput.delete()
-                        spigotOutput.delete()
-                    } else {
-                        logger.warn("Mojang and Spigot mapping should be specified for ${
-                            path.drop(1).takeWhile { it != ':' }
-                        }.")
+                            spigotOutput.copyTo(archiveFile, true)
+                            obfOutput.delete()
+                            spigotOutput.delete()
+                        } else {
+                            logger.warn("Mojang and Spigot mapping should be specified for ${
+                                path.drop(1).takeWhile { it != ':' }
+                            }.")
+                        }
                     }
                 }
             }

--- a/debug.sh
+++ b/debug.sh
@@ -18,7 +18,7 @@ if [ ! -f "$server_folder/$server_script" ]; then
   if [ -f ".server/$server_script" ]; then
     cp ".server/$server_script" "$server_folder/$server_script"
   else
-    wget -qc -P "$server_folder" -N 'https://raw.githubusercontent.com/monun/server-script/master/.server/server.sh'
+    curl 'https://raw.githubusercontent.com/monun/server-script/master/.server/server.sh' > "$server_folder/server.sh"
   fi
 fi
 


### PR DESCRIPTION
- 윈도우 지원을 위해 server.sh 받아오는 명령을 wget 에서 curl 로 변경
- taskGraph 에 debugJar이 있는 경우 모장 매핑 그대로 사용