### PR TITLE
NMS Packet 관련 버그 수정

### DIFF
--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketContainer.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketContainer.kt
@@ -24,6 +24,6 @@ import org.bukkit.entity.Player
 
 class NMSPacketContainer(private val packet: Packet<*>) : PacketContainer {
     override fun sendTo(player: Player) {
-        (player as CraftPlayer).handle.connection.send(packet)
+        (player as CraftPlayer).handle.connection.send(packet, null)
     }
 }

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketSupport.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketSupport.kt
@@ -197,7 +197,7 @@ class NMSPacketSupport : PacketSupport {
     ): NMSPacketContainer {
         val byteBuf = FriendlyByteBuf(Unpooled.buffer())
 
-        byteBuf.writeVarInt(entityId)
+        byteBuf.writeInt(entityId)
         byteBuf.writeByte(data.toInt())
 
         val packet = ClientboundEntityEventPacket(byteBuf)

--- a/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketSupport.kt
+++ b/v1_17_R1/src/main/kotlin/io/github/monun/tap/v1_17_R1/protocol/NMSPacketSupport.kt
@@ -21,6 +21,7 @@ import io.github.monun.tap.fake.createFakeEntity
 import io.github.monun.tap.protocol.PacketSupport
 import io.github.monun.tap.protocol.toProtocolDegrees
 import io.github.monun.tap.protocol.toProtocolDelta
+import io.github.monun.tap.v1_17_R1.fake.NMSEntityTypes
 import io.netty.buffer.Unpooled
 import net.minecraft.network.FriendlyByteBuf
 import net.minecraft.network.protocol.game.ClientboundAddEntityPacket
@@ -44,7 +45,6 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.util.Vector
 import java.util.UUID
 
-import net.minecraft.world.entity.EntityType as NMSEntityType
 import net.minecraft.world.entity.EquipmentSlot as NMSEquipmentSlot
 
 private fun EquipmentSlot.toNMS(): NMSEquipmentSlot {
@@ -71,6 +71,8 @@ class NMSPacketSupport : PacketSupport {
         objectId: Int,
         velocity: Vector
     ): NMSPacketContainer {
+        val entityClass = type.entityClass ?: throw IllegalArgumentException("Unknown EntityType: ${type.name}")
+
         val packet = ClientboundAddEntityPacket(
             entityId,
             uuid,
@@ -79,7 +81,7 @@ class NMSPacketSupport : PacketSupport {
             z,
             yaw,
             pitch,
-            NMSEntityType.byString(type.name).get(),
+            NMSEntityTypes.findType(entityClass),
             objectId,
             CraftVector.toNMS(velocity)
         )


### PR DESCRIPTION
Packet 사용 과정에서 발생한 문제를 해결하였습니다.
 - #7 에서 실수로 사용한 varInt를 int 로 변경하였습니다.
 - 2a81edf83a85816540734b73a2cba834d3b29b2d 에서 null 파라미터가 사라진 것을 되돌렸습니다.
 - #7 에서 NMS의 EntityType을 제대로 가져오지 못하는 문제를 수정하였습니다.