### PR TITLE
Resolve api error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ subprojects {
     }
 
     dependencies {
-        api("io.papermc.paper:paper-api:${Dependency.Paper.Version}-R0.1-SNAPSHOT")
+        compileOnly("io.papermc.paper:paper-api:${Dependency.Paper.Version}-R0.1-SNAPSHOT")
 
         implementation(kotlin("stdlib"))
         implementation(kotlin("reflect"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4G
 
 group=io.github.monun
-version=4.7.0
+version=4.7.1


### PR DESCRIPTION
### 내용
`api` -> `compileOnly`

런타임에서 `paper-api`를 `mavenCentral`에서 가져오려고 해서 발생한 오류 해결.

close #31  