### PR TITLE
:sparkles: PDC Support

### DIFF
--- a/tap-api/src/main/kotlin/io/github/monun/tap/pdc/ExtraPersistentDataTypes.kt
+++ b/tap-api/src/main/kotlin/io/github/monun/tap/pdc/ExtraPersistentDataTypes.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.pdc
+
+import org.bukkit.persistence.PersistentDataAdapterContext
+import org.bukkit.persistence.PersistentDataType
+import java.nio.ByteBuffer
+import java.util.*
+
+object ExtraPersistentDataTypes {
+    val UUID = createType<ByteArray, UUID>({
+        with(ByteBuffer.wrap(it)) {
+            UUID(long, long)
+        }
+    }) {
+        ByteBuffer.wrap(ByteArray(16)).apply {
+            putLong(it.mostSignificantBits)
+            putLong(it.leastSignificantBits)
+        }.array()
+    }
+
+    val BOOLEAN_ARRAY = createType<ByteArray, BooleanArray>({ array ->
+        BooleanArray(array.size) { array[it] != 0.toByte() }
+    }) { array ->
+        ByteArray(array.size) { if (array[it]) 1 else 0 }
+    }
+}
+
+inline fun <reified T : Any, reified Z : Any> createType(crossinline fromPrimitive: (T) -> Z, crossinline toPrimitive: (Z) -> T) =
+    object : PersistentDataType<T, Z> {
+        override fun getPrimitiveType() = T::class.java
+        override fun getComplexType() = Z::class.java
+
+        override fun fromPrimitive(primitive: T, context: PersistentDataAdapterContext): Z = fromPrimitive(primitive)
+
+        override fun toPrimitive(complex: Z, context: PersistentDataAdapterContext) = toPrimitive(complex)
+    }

--- a/tap-api/src/main/kotlin/io/github/monun/tap/pdc/PDCSupport.kt
+++ b/tap-api/src/main/kotlin/io/github/monun/tap/pdc/PDCSupport.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.pdc
+
+import org.bukkit.NamespacedKey
+import org.bukkit.persistence.PersistentDataContainer
+import org.bukkit.persistence.PersistentDataType
+import java.util.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+
+@Suppress("UNCHECKED_CAST", "KotlinConstantConditions")
+fun <T : Any> getPersistentDataType(type: KClass<T>): PersistentDataType<out Any, T> = when (type) {
+    Byte::class -> PersistentDataType.BYTE
+    Short::class -> PersistentDataType.SHORT
+    Int::class -> PersistentDataType.INTEGER
+    Long::class -> PersistentDataType.LONG
+    Double::class -> PersistentDataType.DOUBLE
+    Float::class -> PersistentDataType.FLOAT
+
+    ByteArray::class -> PersistentDataType.BYTE_ARRAY
+    IntArray::class -> PersistentDataType.INTEGER_ARRAY
+
+    String::class -> PersistentDataType.STRING
+
+    PersistentDataContainer::class -> PersistentDataType.TAG_CONTAINER
+    Array<PersistentDataContainer>::class -> PersistentDataType.TAG_CONTAINER_ARRAY
+
+    UUID::class -> ExtraPersistentDataTypes.UUID
+    BooleanArray::class -> ExtraPersistentDataTypes.BOOLEAN_ARRAY
+
+    else -> throw IllegalArgumentException("Failed to find the corresponding persistent data type: $type")
+} as PersistentDataType<out Any, T>
+
+inline operator fun <reified T : Any> PersistentDataContainer.getValue(thisRef: Any?, property: KProperty<*>): T? =
+    this[property.name.asNamespacedKey, getPersistentDataType(T::class)]
+
+inline operator fun <reified T : Any> PersistentDataContainer.get(name: String): T? = this[name.asNamespacedKey, getPersistentDataType(T::class)]
+inline operator fun <reified T : Any> PersistentDataContainer.set(name: String, value: T) {
+    this[name.asNamespacedKey, getPersistentDataType(T::class)] = value
+}
+
+val String.asNamespacedKey
+    get() = NamespacedKey.minecraft(replace("(?<=[a-zA-Z])[A-Z]".toRegex()) { "_${it.value}" }.lowercase())

--- a/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/TapPlugin.kt
+++ b/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/TapPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Monun
+ * Copyright (C) 2023 Monun
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,8 +17,12 @@
 
 package io.github.monun.tap.plugin
 
+import com.destroystokyo.paper.event.player.PlayerJumpEvent
 import io.github.monun.tap.fake.FakeEntity
 import io.github.monun.tap.fake.FakeEntityServer
+import io.github.monun.tap.pdc.getValue
+import io.github.monun.tap.pdc.get
+import io.github.monun.tap.pdc.set
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.Material
@@ -81,11 +85,21 @@ class FakeTest : Listener, Runnable {
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
         fakeEntityServer.addPlayer(event.player)
+
+        val jumpCount: Int? by event.player.persistentDataContainer
+        event.player.sendMessage("그 동안 점프를 ${jumpCount}번 했습니다.")
     }
 
     @EventHandler
     fun onPlayerQuit(event: PlayerQuitEvent) {
         fakeEntityServer.removePlayer(event.player)
+    }
+
+    @EventHandler
+    fun onPlayerJump(event: PlayerJumpEvent) {
+        val dataContainer = event.player.persistentDataContainer
+
+        dataContainer["jumpCount"] = (dataContainer["jumpCount"]?: 0) + 1
     }
 
     private fun testSpawnBasic(loc: Location, blockData: BlockData) {


### PR DESCRIPTION
PDC (PersistentDataContainer) 사용을 간편하게 할 수 있도록 했습니다.

**Delegation**
```kt
val thirstLevel: Int? by player.persistentDataContainer
```
**더 짧은 get/set 문법**
```kt
player.persistentDataContainer["thirstLevel"] = (player.persistentDataContainer["thirstLevel"]?: 100) - 1
```

**새로운 PersistentDataType 2개 추가**
```kt
// UUID 추가
player.persistentDataContainer["ownerId"] = other.uniqueId

// BooleanArray 추가
player.persistentDataContainer["settings"] = BooleanArray(4) { false }
```