### PR TITLE
:pencil2: Removed "Metadata Support" from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
     * 추가적인 인벤토리 함수
     * GitHub를 통한 업데이트
     * Tick 기반 태스크 스케쥴러 (Ticker)
-    * Metadata & PersistentData API 접근성 개선
+    * PersistentData API 접근성 개선
 
 * #### Supported minecraft versions
     * 1.18


### PR DESCRIPTION
https://github.com/monun/tap/commit/6c215c3cbfd8065ffd834781d352c6e633b70a03 커밋으로 Metadata 지원이 제거됐는데 아직 README.md에 남아있습니다.