### PR TITLE
:bug: 지원 안되는 JSON 키 무시

### DIFF
--- a/tap-api/src/main/kotlin/io/github/monun/tap/mojangapi/MojangAPI.kt
+++ b/tap-api/src/main/kotlin/io/github/monun/tap/mojangapi/MojangAPI.kt
@@ -52,7 +52,7 @@ object MojangAPI {
 
         return client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).thenApply { response ->
             val body = response.body()
-            if (body.isBlank()) null else Json.decodeFromString<T>(body)
+            if (body.isBlank()) null else Json { ignoreUnknownKeys = true }.decodeFromString<T>(body)
         }
     }
 
@@ -69,7 +69,7 @@ object MojangAPI {
     ) {
         fun textureProfile() = properties.find { it.name == "textures" }?.let { textures ->
             val string = Base64.getDecoder().decode(textures.value).decodeToString()
-            Json.decodeFromString<TextureProfile>(string)
+            Json { ignoreUnknownKeys = true }.decodeFromString<TextureProfile>(string)
         }
 
         fun profileProperties() = properties.map { it.profileProperty() }


### PR DESCRIPTION
모장 API 서버가 원래 없던 `profileActions`를 제공하는데, `SkinProfile`에는 추가 안되어서 생긴 버그로 추정.

나중에도 이런 문제가 생길 수 있으니 이런 키들을 기본적으로 무시하는 옵션 추가했습니다

close #52 