### PR TITLE
:sparkles: add boolean pdc support

### DIFF
--- a/tap-api/src/main/kotlin/io/github/monun/tap/data/PersistentDataKeychain.kt
+++ b/tap-api/src/main/kotlin/io/github/monun/tap/data/PersistentDataKeychain.kt
@@ -203,4 +203,12 @@ abstract class PersistentDataKeychain {
             ItemStack.deserializeBytes(it)
         })
     }
+
+    protected fun boolean(name: String): PersistentDataKey<Byte, Boolean> {
+        return complex(name, {
+            if (it) 1.toByte() else 0.toByte()
+        }, {
+            it != 0.toByte()
+        })
+    }
 }

--- a/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/test/unit/simple/TestPersistentDataSupport.kt
+++ b/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/test/unit/simple/TestPersistentDataSupport.kt
@@ -50,8 +50,8 @@ class TestPersistentDataSupport : SimpleTestUnit() {
                     data[TestKeychain.enum] = TestEnum.values().random()
                     data[TestKeychain.itemStack] =
                         ItemStack(Material.STONE).apply { editMeta { it.displayName(text("Hello world")) } }
+                    data[TestKeychain.boolean] = true
                     data["message"] = prevMessage + (prevMessage.lastOrNull()?.inc() ?: "A")
-
                 }
             }
 
@@ -65,6 +65,7 @@ class TestPersistentDataSupport : SimpleTestUnit() {
                 message("uuid: ${data[TestKeychain.uuid]}")
                 message("enum: ${data[TestKeychain.enum]}")
                 message("data: ${data[TestKeychain.itemStack]}")
+                message("bool: ${data[TestKeychain.boolean]}")
                 val message: String? by data
                 message("message: $message")
 
@@ -85,6 +86,7 @@ object TestKeychain : PersistentDataKeychain() {
     val complex = complex<TestComplexData>("complex")
     val enum = enum<TestEnum>("enum")
     val itemStack = itemStack("itemStack")
+    val boolean = boolean("bool")
 }
 
 @Serializable


### PR DESCRIPTION
# Overview
* Boolean values support in PDC

# About this PR
This PR introduces boolean support in the library when using PDC.

Since PDC does not natively support boolean values, devs had to create their own boolean adapters unless they use the new `PersistentDataType.BOOLEAN`, which was added recently in Bukkit for convenience.

To reflect the recent Bukkit changes, this PR allows devs to use boolean values in PDC like the code below:
```kt
object SampleKeychain : PersistentDataKeychain() {
    val isSpectator = boolean("is_spectator")
}

var Player.isSpectator
    get() = persistentData[SampleKeychain.isSpectator] ?: false
    set(value) {
        persistentData[SampleKeychain.isSpectator] = value
    }
```