### PR TITLE
:recycle: Improve version fetching methods

### DIFF
--- a/tap-api/src/main/kotlin/io/github/monun/tap/loader/LibraryLoader.kt
+++ b/tap-api/src/main/kotlin/io/github/monun/tap/loader/LibraryLoader.kt
@@ -113,21 +113,11 @@ object LibraryLoader {
     }
 
     val bukkitVersion by lazy {
-        with("v\\d+_\\d+_R\\d+".toPattern().matcher(Bukkit.getServer()::class.java.`package`.name)) {
-            when {
-                find() -> group()
-                else -> throw NoSuchElementException("No such bukkit version exists")
-            }
-        }
+        Bukkit.getServer().bukkitVersion
     }
 
     val minecraftVersion by lazy {
-        with("(?<=\\(MC: )[\\d.]+?(?=\\))".toPattern().matcher(Bukkit.getVersion())) {
-            when {
-                find() -> group()
-                else -> throw NoSuchElementException("No such minecraft version exists")
-            }
-        }
+        Bukkit.getServer().minecraftVersion
     }
 
     val libraryVersion by lazy { "v${minecraftVersion.replace('.', '_')}" }

--- a/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/test/TapTest.kt
+++ b/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/test/TapTest.kt
@@ -3,6 +3,7 @@ package io.github.monun.tap.plugin.test
 import io.github.monun.tap.plugin.test.unit.complex.TestFakeEntityPose
 import io.github.monun.tap.plugin.test.unit.simple.TestConfigSupport
 import io.github.monun.tap.plugin.test.unit.simple.TestPersistentDataSupport
+import io.github.monun.tap.plugin.test.unit.simple.TestNewVersionFetchSupport
 import org.bukkit.Bukkit
 import org.bukkit.event.HandlerList
 import org.bukkit.plugin.Plugin
@@ -12,7 +13,8 @@ object TapTest {
 
     private val simpleTestMap: Map<String, () -> SimpleTestUnit> = mapOf(
         "persistent-data" to ::TestPersistentDataSupport,
-        "config-test" to ::TestConfigSupport
+        "config-test" to ::TestConfigSupport,
+        "version-fetch-test" to ::TestNewVersionFetchSupport
     )
 
     private val complexTestMap: Map<String, () -> ComplexTestUnit> = mapOf(

--- a/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/test/unit/simple/TestNewVersionFetchSupport.kt
+++ b/tap-plugin/src/main/kotlin/io/github/monun/tap/plugin/test/unit/simple/TestNewVersionFetchSupport.kt
@@ -1,0 +1,29 @@
+package io.github.monun.tap.plugin.test.unit.simple
+
+import io.github.monun.tap.plugin.test.SimpleTestUnit
+import org.bukkit.Bukkit
+
+class TestNewVersionFetchSupport : SimpleTestUnit() {
+    override fun test() {
+        val oldMinecraftVersionMethod = with("(?<=\\(MC: )[\\d.]+?(?=\\))".toPattern().matcher(Bukkit.getVersion())) {
+            when {
+                find() -> group()
+                else -> throw NoSuchElementException("No such minecraft version exists")
+            }
+        }
+
+        val oldBukkitVersionMethod = with("v\\d+_\\d+_R\\d+".toPattern().matcher(Bukkit.getServer()::class.java.`package`.name)) {
+            when {
+                find() -> group()
+                else -> throw NoSuchElementException("No such bukkit version exists")
+            }
+        }
+
+
+        message("fetched minecraft version (old): $oldMinecraftVersionMethod")
+        message("fetched minecraft version (new): ${Bukkit.getServer().minecraftVersion}")
+
+        message("fetched bukkit version (old): $oldBukkitVersionMethod")
+        message("fetched bukkit version (new): ${Bukkit.getServer().bukkitVersion}")
+    }
+}


### PR DESCRIPTION
Paper has recently released an announcement that they might only provide jars without relocation in the future.

This PR introduces the replacement of existing version fetching methods in favor of the use of methods `Server#getBukkitVersion` and `Server#getMinecraftVersion` as package version parsing would not be supported in the future.

The image below gives a direct comparison of the return values of these fetching methods:

![image](https://github.com/monun/tap/assets/68156872/6b27b919-e443-46f4-a1d2-4ae228b6b454)
