### PR TITLE
Support 1.20.2 ~ 1.20.4 without riding offset methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4G
 group=io.github.monun
-version=4.9.8
+version=5.0.0

--- a/tap-dongle/build.gradle.kts
+++ b/tap-dongle/build.gradle.kts
@@ -1,7 +1,7 @@
 import io.papermc.paperweight.tasks.RemapJar
 
 plugins {
-    id("io.papermc.paperweight.userdev") version "1.5.5" apply false
+    id("io.papermc.paperweight.userdev") version "1.5.11" apply false
 }
 
 subprojects {

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/fake/NMSEntityTypes.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/fake/NMSEntityTypes.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_2.fake
+
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.entity.EntityType
+import org.bukkit.Bukkit
+import org.bukkit.craftbukkit.v1_20_R2.CraftServer
+import org.bukkit.entity.Entity as BukkitEntity
+
+/**
+ * @author Nemo
+ */
+internal object NMSEntityTypes {
+    private val ENTITIES = HashMap<Class<out BukkitEntity>, EntityType<*>>()
+
+    init {
+        val server: MinecraftServer = (Bukkit.getServer() as CraftServer).server
+        val level = server.allLevels.first()
+
+        BuiltInRegistries.ENTITY_TYPE.forEach { type ->
+            type.create(level)?.let { entity ->
+                val bukkitClass = entity.bukkitEntity.javaClass
+                val interfaces = bukkitClass.interfaces
+
+                ENTITIES[bukkitClass.asSubclass(BukkitEntity::class.java)] = type
+
+                for (i in interfaces) {
+                    if (BukkitEntity::class.java.isAssignableFrom(i)) {
+                        ENTITIES[i.asSubclass(BukkitEntity::class.java)] = type
+                    }
+                }
+            }
+        }
+    }
+
+    @JvmStatic
+    fun findType(bukkitClass: Class<out BukkitEntity>): EntityType<*> {
+        return ENTITIES[bukkitClass] ?: error("Unknown entity type $bukkitClass")
+    }
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/fake/NMSFakeSupport.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/fake/NMSFakeSupport.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_2.fake
+
+import com.destroystokyo.paper.profile.ProfileProperty
+import com.mojang.authlib.GameProfile
+import com.mojang.authlib.properties.Property
+import io.github.monun.tap.fake.FakeSkinParts
+import io.github.monun.tap.fake.FakeSupport
+import io.github.monun.tap.v1_20_2.network.NMSEmptyConnection
+import io.github.monun.tap.v1_20_2.network.NMSEmptyPacketListener
+import io.github.monun.tap.v1_20_2.protocol.NMSPacketContainer
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
+import net.minecraft.server.level.ClientInformation
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.network.CommonListenerCookie
+import net.minecraft.world.entity.item.FallingBlockEntity
+import net.minecraft.world.entity.item.ItemEntity
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.block.data.BlockData
+import org.bukkit.craftbukkit.v1_20_R2.CraftServer
+import org.bukkit.craftbukkit.v1_20_R2.CraftWorld
+import org.bukkit.craftbukkit.v1_20_R2.block.data.CraftBlockData
+import org.bukkit.craftbukkit.v1_20_R2.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack
+import org.bukkit.entity.*
+import org.bukkit.inventory.ItemStack
+import java.util.*
+
+/**
+ * @author Nemo
+ */
+class NMSFakeSupport : FakeSupport {
+
+    override fun getNetworkId(entity: Entity): Int {
+        entity as CraftEntity
+
+        return BuiltInRegistries.ENTITY_TYPE.getId(entity.handle.type)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Entity> createEntity(entityClass: Class<out Entity>, world: World): T {
+        return NMSEntityTypes.findType(entityClass).run {
+            val nmsWorld = (world as CraftWorld).handle
+            this.create(nmsWorld)?.bukkitEntity as T
+        }
+    }
+
+    override fun isInvisible(entity: Entity): Boolean {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        return nmsEntity.isInvisible
+    }
+
+    override fun setInvisible(entity: Entity, invisible: Boolean) {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        nmsEntity.isInvisible = invisible
+    }
+
+    private val nmsPoses = net.minecraft.world.entity.Pose.values()
+    override fun setPose(entity: Entity, pose: Pose) {
+        (entity as CraftEntity).handle.pose = nmsPoses[pose.ordinal]
+    }
+
+    override fun setLocation(
+        entity: Entity,
+        loc: Location
+    ) {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        loc.run {
+            nmsEntity.setLevel((world as CraftWorld).handle)
+            nmsEntity.moveTo(x, y, z, yaw, pitch)
+        }
+    }
+
+    @Deprecated("Unimplemented due to inner offset method change", ReplaceWith(""))
+    override fun getMountedYOffset(entity: Entity): Double {
+        return 0.0
+    }
+
+    @Deprecated("Unimplemented due to inner offset method change", ReplaceWith(""))
+    override fun getYOffset(entity: Entity): Double {
+        return 0.0
+    }
+
+    /* Modified */
+    override fun createSpawnPacket(entity: Entity): Array<NMSPacketContainer> {
+        val packets = arrayListOf<NMSPacketContainer>()
+        entity as CraftEntity
+        if (entity is Player) {
+            packets.add(
+                NMSPacketContainer(
+                    ClientboundPlayerInfoUpdatePacket(
+                        ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER,
+                        entity.handle as ServerPlayer
+                    )
+                )
+            )
+        }
+        packets.add(NMSPacketContainer(entity.handle.addEntityPacket))
+
+        return packets.toTypedArray()
+    }
+
+    override fun createFallingBlock(blockData: BlockData): FallingBlock {
+        val entity =
+            FallingBlockEntity(
+                (Bukkit.getWorlds().first() as CraftWorld).handle,
+                0.0,
+                0.0,
+                0.0,
+                (blockData as CraftBlockData).state
+            )
+
+        return entity.bukkitEntity as FallingBlock
+    }
+
+    override fun createItemEntity(item: ItemStack): Item {
+        val entity =
+            ItemEntity(
+                (Bukkit.getWorlds().first() as CraftWorld).handle,
+                0.0,
+                0.0,
+                0.0,
+                CraftItemStack.asNMSCopy(item)
+            )
+        entity.setNeverPickUp()
+
+        return entity.bukkitEntity as Item
+    }
+
+    override fun createPlayerEntity(
+        name: String,
+        profileProperties: Set<ProfileProperty>,
+        skinParts: FakeSkinParts,
+        uniqueId: UUID
+    ): Player {
+        val server = (Bukkit.getServer() as CraftServer).handle.server
+        val gameProfile = GameProfile(uniqueId, name).apply {
+            for (property in profileProperties) {
+                val propertyName = property.name
+                properties.put(propertyName, Property(propertyName, property.value, property.signature))
+            }
+        }
+        val clientInfo = ClientInformation.createDefault()
+
+        val player = ServerPlayer(
+            server,
+            (Bukkit.getWorlds().first() as CraftWorld).handle,
+            gameProfile,
+            clientInfo
+        )
+
+
+        player.connection =
+            NMSEmptyPacketListener(server, NMSEmptyConnection, player, CommonListenerCookie(gameProfile, 0, clientInfo))
+
+        player.entityData.set(
+            ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION,
+            skinParts.raw.toByte()
+        )
+
+        return player.bukkitEntity
+    }
+
+    override fun setSkinParts(player: Player, raw: Int) {
+        (player as CraftPlayer).handle.apply {
+            entityData.set(ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION, raw.toByte())
+        }
+    }
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/item/NMSItemSupport.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/item/NMSItemSupport.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_2.item
+
+import io.github.monun.tap.item.ItemSupport
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.item.ItemStack
+import org.bukkit.craftbukkit.v1_20_R2.CraftEquipmentSlot
+import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftInventoryPlayer
+import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack as BukkitItemStack
+import org.bukkit.inventory.PlayerInventory as BukkitPlayerInventory
+
+class NMSItemSupport : ItemSupport {
+    override fun saveToJsonString(item: BukkitItemStack): String {
+        val nmsItem = CraftItemStack.asNMSCopy(item)
+        return nmsItem.save(CompoundTag()).toString()
+    }
+
+    override fun damageArmor(playerInventory: BukkitPlayerInventory, attackDamage: Double) {
+        val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
+        
+        nmsInventory.hurtArmor(
+            nmsInventory.player.damageSources().lava(),
+            attackDamage.toFloat(),
+            Inventory.ALL_ARMOR_SLOTS
+        )
+    }
+
+    override fun damageSlot(playerInventory: BukkitPlayerInventory, slot: EquipmentSlot, damage: Int) {
+        val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
+        val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+        val nmsItem = nmsInventory.getItem(slot)
+
+        if (!nmsItem.isEmpty) {
+            nmsItem.hurtAndBreak(damage, (playerInventory.holder as CraftPlayer).handle) { player ->
+                player.broadcastBreakEvent(nmsSlot)
+            }
+        }
+    }
+}
+
+internal fun Inventory.getItem(slot: EquipmentSlot): ItemStack {
+    return when (slot) {
+        EquipmentSlot.HAND -> getSelected()
+        EquipmentSlot.OFF_HAND -> offhand[0]
+        EquipmentSlot.FEET -> armorContents[0]
+        EquipmentSlot.LEGS -> armorContents[1]
+        EquipmentSlot.CHEST -> armorContents[2]
+        EquipmentSlot.HEAD -> armorContents[3]
+    }
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/network/NMSEmptyChannel.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/network/NMSEmptyChannel.kt
@@ -1,0 +1,60 @@
+package io.github.monun.tap.v1_20_2.network
+
+import io.netty.channel.*
+import java.net.SocketAddress
+
+class NMSEmptyChannel(parent: Channel?) : AbstractChannel(parent) {
+    private val config: ChannelConfig = DefaultChannelConfig(this)
+    override fun config(): ChannelConfig {
+        config.setAutoRead(true)
+        return config
+    }
+
+    @Throws(Exception::class)
+    override fun doBeginRead() {
+    }
+
+    @Throws(Exception::class)
+    override fun doBind(arg0: SocketAddress) {
+    }
+
+    @Throws(Exception::class)
+    override fun doClose() {
+    }
+
+    @Throws(Exception::class)
+    override fun doDisconnect() {
+    }
+
+    @Throws(Exception::class)
+    override fun doWrite(arg0: ChannelOutboundBuffer) {
+    }
+
+    override fun isActive(): Boolean {
+        return false
+    }
+
+    override fun isCompatible(arg0: EventLoop): Boolean {
+        return false
+    }
+
+    override fun isOpen(): Boolean {
+        return false
+    }
+
+    override fun localAddress0(): SocketAddress? {
+        return null
+    }
+
+    override fun metadata(): ChannelMetadata {
+        return ChannelMetadata(true)
+    }
+
+    override fun newUnsafe(): AbstractUnsafe? {
+        return null
+    }
+
+    override fun remoteAddress0(): SocketAddress? {
+        return null
+    }
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/network/NMSEmptyConnection.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/network/NMSEmptyConnection.kt
@@ -1,0 +1,40 @@
+package io.github.monun.tap.v1_20_2.network
+
+import net.minecraft.network.Connection
+import net.minecraft.network.PacketListener
+import net.minecraft.network.PacketSendListener
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.PacketFlow
+import java.lang.invoke.MethodHandles
+import java.net.SocketAddress
+
+object NMSEmptyConnection : Connection(PacketFlow.CLIENTBOUND) {
+    init {
+        channel = NMSEmptyChannel(null)
+        address = object : SocketAddress() {
+            private val serialVersionUID = 8207338859896320185L
+        }
+    }
+
+    override fun isConnected(): Boolean {
+        return true
+    }
+
+    override fun send(packet: Packet<*>, genericfuturelistener: PacketSendListener?) {}
+    override fun setListener(pl: PacketListener) {
+        try {
+            val lookup = MethodHandles.lookup()
+
+            val connectionJavaClass = Connection::class.java
+            val connectionPacketListener = connectionJavaClass.getDeclaredField("q")
+            val connectionDisconnectListener = connectionJavaClass.getDeclaredField("p")
+            connectionPacketListener.isAccessible = true
+            connectionDisconnectListener.isAccessible = true
+
+            lookup.unreflectSetter(connectionPacketListener).invoke(this, pl)
+            lookup.unreflectSetter(connectionDisconnectListener).invoke(this, null)
+        } catch (e: Throwable) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/network/NMSEmptyPacketListener.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/network/NMSEmptyPacketListener.kt
@@ -1,0 +1,19 @@
+package io.github.monun.tap.v1_20_2.network
+
+import net.minecraft.network.Connection
+import net.minecraft.network.protocol.Packet
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.network.CommonListenerCookie
+import net.minecraft.server.network.ServerGamePacketListenerImpl
+
+
+class NMSEmptyPacketListener(
+    minecraftServer: MinecraftServer,
+    networkManager: Connection,
+    entityPlayer: ServerPlayer,
+    clc: CommonListenerCookie
+) :
+    ServerGamePacketListenerImpl(minecraftServer, networkManager, entityPlayer, clc) {
+    override fun send(packet: Packet<*>) {}
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/protocol/NMSPacketContainer.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/protocol/NMSPacketContainer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_2.protocol
+
+import io.github.monun.tap.protocol.PacketContainer
+import net.minecraft.network.protocol.Packet
+import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer
+import org.bukkit.entity.Player
+
+
+class NMSPacketContainer(private val packet: Packet<*>) : PacketContainer {
+    override fun sendTo(player: Player) {
+        (player as CraftPlayer).handle.connection.send(packet, null)
+    }
+}

--- a/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/protocol/NMSPacketSupport.kt
+++ b/tap-dongle/v1.20.2/src/main/kotlin/io/github/monun/tap/v1_20_2/protocol/NMSPacketSupport.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_2.protocol
+
+import io.github.monun.tap.protocol.*
+import io.netty.buffer.Unpooled
+import it.unimi.dsi.fastutil.ints.IntArrayList
+import net.minecraft.network.FriendlyByteBuf
+import net.minecraft.network.protocol.game.*
+import net.minecraft.world.phys.Vec3
+import org.bukkit.craftbukkit.v1_20_R2.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R2.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import org.bukkit.util.Vector
+import java.util.*
+import net.minecraft.world.entity.EquipmentSlot as NMSEquipmentSlot
+
+class NMSPacketSupport : PacketSupport {
+    companion object {
+        private fun EquipmentSlot.toNMS(): NMSEquipmentSlot {
+            return when (this) {
+                EquipmentSlot.HAND -> NMSEquipmentSlot.MAINHAND
+                EquipmentSlot.OFF_HAND -> NMSEquipmentSlot.OFFHAND
+                EquipmentSlot.FEET -> NMSEquipmentSlot.FEET
+                EquipmentSlot.LEGS -> NMSEquipmentSlot.LEGS
+                EquipmentSlot.CHEST -> NMSEquipmentSlot.CHEST
+                EquipmentSlot.HEAD -> NMSEquipmentSlot.HEAD
+            }
+        }
+    }
+
+    override fun entityMetadata(entity: Entity): NMSPacketContainer {
+        entity as CraftEntity
+
+        val entityId = entity.entityId
+        val entityData = entity.handle.entityData
+
+        // nonDefaultValues가 null일때 ClientboundSetEntityDataPacket.pack(ClientboundSetEntityDataPacket.java:17) 에서 NPE 발생
+        val packet = ClientboundSetEntityDataPacket(entityId, entityData.nonDefaultValues ?: emptyList())
+        return NMSPacketContainer(packet)
+    }
+
+
+    override fun entityEquipment(entityId: Int, equipments: Map<EquipmentSlot, ItemStack>): NMSPacketContainer {
+        val packet = ClientboundSetEquipmentPacket(entityId, equipments.map { entry ->
+            com.mojang.datafixers.util.Pair(entry.key.toNMS(), CraftItemStack.asNMSCopy(entry.value))
+        })
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityTeleport(
+        entityId: Int,
+        x: Double,
+        y: Double,
+        z: Double,
+        yaw: Float,
+        pitch: Float,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeDouble(x)
+        byteBuf.writeDouble(y)
+        byteBuf.writeDouble(z)
+        byteBuf.writeByte(yaw.toProtocolDegrees())
+        byteBuf.writeByte(pitch.toProtocolDegrees())
+        byteBuf.writeBoolean(onGround)
+
+        val packet = ClientboundTeleportEntityPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun relEntityMove(
+        entityId: Int,
+        deltaX: Short,
+        deltaY: Short,
+        deltaZ: Short,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val packet = ClientboundMoveEntityPacket.Pos(entityId, deltaX, deltaY, deltaZ, onGround)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun relEntityMoveLook(
+        entityId: Int,
+        deltaX: Short,
+        deltaY: Short,
+        deltaZ: Short,
+        yaw: Float,
+        pitch: Float,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val packet = ClientboundMoveEntityPacket.PosRot(
+            entityId,
+            deltaX,
+            deltaY,
+            deltaZ,
+            yaw.toProtocolDegrees().toByte(),
+            pitch.toProtocolDegrees().toByte(),
+            onGround
+        )
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityRotation(entityId: Int, yaw: Float, pitch: Float, onGround: Boolean): PacketContainer {
+        return NMSPacketContainer(
+            ClientboundMoveEntityPacket.Rot(
+                entityId,
+                yaw.toProtocolDegrees().toByte(),
+                pitch.toProtocolDegrees().toByte(),
+                onGround
+            )
+        )
+    }
+
+    override fun entityHeadLook(entityId: Int, yaw: Float): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeByte(yaw.toProtocolDegrees())
+
+        return NMSPacketContainer(ClientboundRotateHeadPacket(byteBuf))
+    }
+
+    override fun entityVelocity(entityId: Int, vector: Vector): NMSPacketContainer {
+        val packet = ClientboundSetEntityMotionPacket(entityId, Vec3(vector.x, vector.y, vector.z))
+
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityStatus(
+        entityId: Int,
+        data: Byte
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeInt(entityId)
+        byteBuf.writeByte(data.toInt())
+
+        val packet = ClientboundEntityEventPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityAnimation(
+        entityId: Int,
+        action: Int
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeByte(action)
+
+        return NMSPacketContainer(ClientboundAnimatePacket(byteBuf))
+    }
+
+    override fun hurtAnimation(entityId: Int, yaw: Float): PacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeFloat(yaw)
+
+        val packet = ClientboundHurtAnimationPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun mount(
+        entityId: Int,
+        mountEntityIds: IntArray
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeVarIntArray(mountEntityIds)
+
+        val packet = ClientboundSetPassengersPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun takeItem(
+        entityId: Int,
+        collectorId: Int,
+        stackAmount: Int
+    ): NMSPacketContainer {
+        val packet = ClientboundTakeItemEntityPacket(entityId, collectorId, stackAmount)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun removeEntity(
+        entityId: Int
+    ): NMSPacketContainer {
+        val packet = ClientboundRemoveEntitiesPacket(entityId)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun removeEntities(vararg entityIds: Int): PacketContainer {
+        return NMSPacketContainer(ClientboundRemoveEntitiesPacket(IntArrayList((entityIds))))
+    }
+
+    override fun containerSetSlot(containerId: Int, stateId: Int, slot: Int, item: ItemStack?): NMSPacketContainer {
+        return NMSPacketContainer(
+            ClientboundContainerSetSlotPacket(
+                containerId,
+                stateId,
+                slot,
+                CraftItemStack.asNMSCopy(item)
+            )
+        )
+    }
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun playerInfoAction(action: PlayerInfoAction, player: Player): PacketContainer {
+        if (action == PlayerInfoAction.REMOVE) {
+            return NMSPacketContainer(ClientboundPlayerInfoRemovePacket(listOf(player.uniqueId)))
+        }
+
+        when (action) {
+            PlayerInfoAction.ADD -> ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER
+            PlayerInfoAction.GAME_MODE -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE
+            PlayerInfoAction.LATENCY -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LATENCY
+            PlayerInfoAction.DISPLAY_NAME -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME
+            else -> throw IllegalArgumentException("impossible")
+        }.let { nmsAction ->
+            return NMSPacketContainer(ClientboundPlayerInfoUpdatePacket(nmsAction, (player as CraftPlayer).handle))
+        }
+    }
+
+    override fun playerInfoUpdate(action: PlayerInfoUpdateAction, player: Player): PacketContainer {
+        return when (action) {
+            PlayerInfoUpdateAction.ADD_PLAYER -> ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER
+            PlayerInfoUpdateAction.INITIALIZE_CHAT -> ClientboundPlayerInfoUpdatePacket.Action.INITIALIZE_CHAT
+            PlayerInfoUpdateAction.UPDATE_GAME_MODE -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE
+            PlayerInfoUpdateAction.UPDATE_LISTED -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED
+            PlayerInfoUpdateAction.UPDATE_LATENCY -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LATENCY
+            PlayerInfoUpdateAction.UPDATE_DISPLAY_NAME -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME
+        }.let { nmsAction ->
+            NMSPacketContainer(ClientboundPlayerInfoUpdatePacket(nmsAction, (player as CraftPlayer).handle))
+        }
+    }
+
+    override fun playerInfoRemove(list: List<UUID>): PacketContainer {
+        return NMSPacketContainer(ClientboundPlayerInfoRemovePacket(list))
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/fake/NMSEntityTypes.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/fake/NMSEntityTypes.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_3.fake
+
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.entity.EntityType
+import org.bukkit.Bukkit
+import org.bukkit.craftbukkit.v1_20_R3.CraftServer
+import org.bukkit.entity.Entity as BukkitEntity
+
+/**
+ * @author Nemo
+ */
+internal object NMSEntityTypes {
+    private val ENTITIES = HashMap<Class<out BukkitEntity>, EntityType<*>>()
+
+    init {
+        val server: MinecraftServer = (Bukkit.getServer() as CraftServer).server
+        val level = server.allLevels.first()
+
+        BuiltInRegistries.ENTITY_TYPE.forEach { type ->
+            type.create(level)?.let { entity ->
+                val bukkitClass = entity.bukkitEntity.javaClass
+                val interfaces = bukkitClass.interfaces
+
+                ENTITIES[bukkitClass.asSubclass(BukkitEntity::class.java)] = type
+
+                for (i in interfaces) {
+                    if (BukkitEntity::class.java.isAssignableFrom(i)) {
+                        ENTITIES[i.asSubclass(BukkitEntity::class.java)] = type
+                    }
+                }
+            }
+        }
+    }
+
+    @JvmStatic
+    fun findType(bukkitClass: Class<out BukkitEntity>): EntityType<*> {
+        return ENTITIES[bukkitClass] ?: error("Unknown entity type $bukkitClass")
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/fake/NMSFakeSupport.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/fake/NMSFakeSupport.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_3.fake
+
+import com.destroystokyo.paper.profile.ProfileProperty
+import com.mojang.authlib.GameProfile
+import com.mojang.authlib.properties.Property
+import io.github.monun.tap.fake.FakeSkinParts
+import io.github.monun.tap.fake.FakeSupport
+import io.github.monun.tap.v1_20_3.network.NMSEmptyConnection
+import io.github.monun.tap.v1_20_3.network.NMSEmptyPacketListener
+import io.github.monun.tap.v1_20_3.protocol.NMSPacketContainer
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
+import net.minecraft.server.level.ClientInformation
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.network.CommonListenerCookie
+import net.minecraft.world.entity.item.FallingBlockEntity
+import net.minecraft.world.entity.item.ItemEntity
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.block.data.BlockData
+import org.bukkit.craftbukkit.v1_20_R3.CraftServer
+import org.bukkit.craftbukkit.v1_20_R3.CraftWorld
+import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
+import org.bukkit.entity.*
+import org.bukkit.inventory.ItemStack
+import java.util.*
+
+/**
+ * @author Nemo
+ */
+class NMSFakeSupport : FakeSupport {
+
+    override fun getNetworkId(entity: Entity): Int {
+        entity as CraftEntity
+
+        return BuiltInRegistries.ENTITY_TYPE.getId(entity.handle.type)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Entity> createEntity(entityClass: Class<out Entity>, world: World): T {
+        return NMSEntityTypes.findType(entityClass).run {
+            val nmsWorld = (world as CraftWorld).handle
+            this.create(nmsWorld)?.bukkitEntity as T
+        }
+    }
+
+    override fun isInvisible(entity: Entity): Boolean {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        return nmsEntity.isInvisible
+    }
+
+    override fun setInvisible(entity: Entity, invisible: Boolean) {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        nmsEntity.isInvisible = invisible
+    }
+
+    private val nmsPoses = net.minecraft.world.entity.Pose.values()
+    override fun setPose(entity: Entity, pose: Pose) {
+        (entity as CraftEntity).handle.pose = nmsPoses[pose.ordinal]
+    }
+
+    override fun setLocation(
+        entity: Entity,
+        loc: Location
+    ) {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        loc.run {
+            nmsEntity.setLevel((world as CraftWorld).handle)
+            nmsEntity.moveTo(x, y, z, yaw, pitch)
+        }
+    }
+
+    @Deprecated("Unimplemented due to inner offset method change", ReplaceWith(""))
+    override fun getMountedYOffset(entity: Entity): Double {
+        return 0.0
+    }
+
+    @Deprecated("Unimplemented due to inner offset method change", ReplaceWith(""))
+    override fun getYOffset(entity: Entity): Double {
+        return 0.0
+    }
+
+    /* Modified */
+    override fun createSpawnPacket(entity: Entity): Array<NMSPacketContainer> {
+        val packets = arrayListOf<NMSPacketContainer>()
+        entity as CraftEntity
+        if (entity is Player) {
+            packets.add(
+                NMSPacketContainer(
+                    ClientboundPlayerInfoUpdatePacket(
+                        ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER,
+                        entity.handle as ServerPlayer
+                    )
+                )
+            )
+        }
+        packets.add(NMSPacketContainer(entity.handle.addEntityPacket))
+
+        return packets.toTypedArray()
+    }
+
+    override fun createFallingBlock(blockData: BlockData): FallingBlock {
+        val entity =
+            FallingBlockEntity(
+                (Bukkit.getWorlds().first() as CraftWorld).handle,
+                0.0,
+                0.0,
+                0.0,
+                (blockData as CraftBlockData).state
+            )
+
+        return entity.bukkitEntity as FallingBlock
+    }
+
+    override fun createItemEntity(item: ItemStack): Item {
+        val entity =
+            ItemEntity(
+                (Bukkit.getWorlds().first() as CraftWorld).handle,
+                0.0,
+                0.0,
+                0.0,
+                CraftItemStack.asNMSCopy(item)
+            )
+        entity.setNeverPickUp()
+
+        return entity.bukkitEntity as Item
+    }
+
+    override fun createPlayerEntity(
+        name: String,
+        profileProperties: Set<ProfileProperty>,
+        skinParts: FakeSkinParts,
+        uniqueId: UUID
+    ): Player {
+        val server = (Bukkit.getServer() as CraftServer).handle.server
+        val gameProfile = GameProfile(uniqueId, name).apply {
+            for (property in profileProperties) {
+                val propertyName = property.name
+                properties.put(propertyName, Property(propertyName, property.value, property.signature))
+            }
+        }
+        val clientInfo = ClientInformation.createDefault()
+
+        val player = ServerPlayer(
+            server,
+            (Bukkit.getWorlds().first() as CraftWorld).handle,
+            gameProfile,
+            clientInfo
+        )
+
+
+        player.connection =
+            NMSEmptyPacketListener(server, NMSEmptyConnection, player, CommonListenerCookie(gameProfile, 0, clientInfo))
+
+        player.entityData.set(
+            ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION,
+            skinParts.raw.toByte()
+        )
+
+        return player.bukkitEntity
+    }
+
+    override fun setSkinParts(player: Player, raw: Int) {
+        (player as CraftPlayer).handle.apply {
+            entityData.set(ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION, raw.toByte())
+        }
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/item/NMSItemSupport.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/item/NMSItemSupport.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_3.item
+
+import io.github.monun.tap.item.ItemSupport
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.item.ItemStack
+import org.bukkit.craftbukkit.v1_20_R3.CraftEquipmentSlot
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftInventoryPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack as BukkitItemStack
+import org.bukkit.inventory.PlayerInventory as BukkitPlayerInventory
+
+class NMSItemSupport : ItemSupport {
+    override fun saveToJsonString(item: BukkitItemStack): String {
+        val nmsItem = CraftItemStack.asNMSCopy(item)
+        return nmsItem.save(CompoundTag()).toString()
+    }
+
+    override fun damageArmor(playerInventory: BukkitPlayerInventory, attackDamage: Double) {
+        val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
+        
+        nmsInventory.hurtArmor(
+            nmsInventory.player.damageSources().lava(),
+            attackDamage.toFloat(),
+            Inventory.ALL_ARMOR_SLOTS
+        )
+    }
+
+    override fun damageSlot(playerInventory: BukkitPlayerInventory, slot: EquipmentSlot, damage: Int) {
+        val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
+        val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+        val nmsItem = nmsInventory.getItem(slot)
+
+        if (!nmsItem.isEmpty) {
+            nmsItem.hurtAndBreak(damage, (playerInventory.holder as CraftPlayer).handle) { player ->
+                player.broadcastBreakEvent(nmsSlot)
+            }
+        }
+    }
+}
+
+internal fun Inventory.getItem(slot: EquipmentSlot): ItemStack {
+    return when (slot) {
+        EquipmentSlot.HAND -> getSelected()
+        EquipmentSlot.OFF_HAND -> offhand[0]
+        EquipmentSlot.FEET -> armorContents[0]
+        EquipmentSlot.LEGS -> armorContents[1]
+        EquipmentSlot.CHEST -> armorContents[2]
+        EquipmentSlot.HEAD -> armorContents[3]
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/network/NMSEmptyChannel.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/network/NMSEmptyChannel.kt
@@ -1,0 +1,60 @@
+package io.github.monun.tap.v1_20_3.network
+
+import io.netty.channel.*
+import java.net.SocketAddress
+
+class NMSEmptyChannel(parent: Channel?) : AbstractChannel(parent) {
+    private val config: ChannelConfig = DefaultChannelConfig(this)
+    override fun config(): ChannelConfig {
+        config.setAutoRead(true)
+        return config
+    }
+
+    @Throws(Exception::class)
+    override fun doBeginRead() {
+    }
+
+    @Throws(Exception::class)
+    override fun doBind(arg0: SocketAddress) {
+    }
+
+    @Throws(Exception::class)
+    override fun doClose() {
+    }
+
+    @Throws(Exception::class)
+    override fun doDisconnect() {
+    }
+
+    @Throws(Exception::class)
+    override fun doWrite(arg0: ChannelOutboundBuffer) {
+    }
+
+    override fun isActive(): Boolean {
+        return false
+    }
+
+    override fun isCompatible(arg0: EventLoop): Boolean {
+        return false
+    }
+
+    override fun isOpen(): Boolean {
+        return false
+    }
+
+    override fun localAddress0(): SocketAddress? {
+        return null
+    }
+
+    override fun metadata(): ChannelMetadata {
+        return ChannelMetadata(true)
+    }
+
+    override fun newUnsafe(): AbstractUnsafe? {
+        return null
+    }
+
+    override fun remoteAddress0(): SocketAddress? {
+        return null
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/network/NMSEmptyConnection.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/network/NMSEmptyConnection.kt
@@ -1,0 +1,40 @@
+package io.github.monun.tap.v1_20_3.network
+
+import net.minecraft.network.Connection
+import net.minecraft.network.PacketListener
+import net.minecraft.network.PacketSendListener
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.PacketFlow
+import java.lang.invoke.MethodHandles
+import java.net.SocketAddress
+
+object NMSEmptyConnection : Connection(PacketFlow.CLIENTBOUND) {
+    init {
+        channel = NMSEmptyChannel(null)
+        address = object : SocketAddress() {
+            private val serialVersionUID = 8207338859896320185L
+        }
+    }
+
+    override fun isConnected(): Boolean {
+        return true
+    }
+
+    override fun send(packet: Packet<*>, genericfuturelistener: PacketSendListener?) {}
+    override fun setListener(pl: PacketListener) {
+        try {
+            val lookup = MethodHandles.lookup()
+
+            val connectionJavaClass = Connection::class.java
+            val connectionPacketListener = connectionJavaClass.getDeclaredField("q")
+            val connectionDisconnectListener = connectionJavaClass.getDeclaredField("p")
+            connectionPacketListener.isAccessible = true
+            connectionDisconnectListener.isAccessible = true
+
+            lookup.unreflectSetter(connectionPacketListener).invoke(this, pl)
+            lookup.unreflectSetter(connectionDisconnectListener).invoke(this, null)
+        } catch (e: Throwable) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/network/NMSEmptyPacketListener.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/network/NMSEmptyPacketListener.kt
@@ -1,0 +1,19 @@
+package io.github.monun.tap.v1_20_3.network
+
+import net.minecraft.network.Connection
+import net.minecraft.network.protocol.Packet
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.network.CommonListenerCookie
+import net.minecraft.server.network.ServerGamePacketListenerImpl
+
+
+class NMSEmptyPacketListener(
+    minecraftServer: MinecraftServer,
+    networkManager: Connection,
+    entityPlayer: ServerPlayer,
+    clc: CommonListenerCookie
+) :
+    ServerGamePacketListenerImpl(minecraftServer, networkManager, entityPlayer, clc) {
+    override fun send(packet: Packet<*>) {}
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/protocol/NMSPacketContainer.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/protocol/NMSPacketContainer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_3.protocol
+
+import io.github.monun.tap.protocol.PacketContainer
+import net.minecraft.network.protocol.Packet
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.entity.Player
+
+
+class NMSPacketContainer(private val packet: Packet<*>) : PacketContainer {
+    override fun sendTo(player: Player) {
+        (player as CraftPlayer).handle.connection.send(packet, null)
+    }
+}

--- a/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/protocol/NMSPacketSupport.kt
+++ b/tap-dongle/v1.20.3/src/main/kotlin/io/github/monun/tap/v1_20_3/protocol/NMSPacketSupport.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_3.protocol
+
+import io.github.monun.tap.protocol.*
+import io.netty.buffer.Unpooled
+import it.unimi.dsi.fastutil.ints.IntArrayList
+import net.minecraft.network.FriendlyByteBuf
+import net.minecraft.network.protocol.game.*
+import net.minecraft.world.phys.Vec3
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import org.bukkit.util.Vector
+import java.util.*
+import net.minecraft.world.entity.EquipmentSlot as NMSEquipmentSlot
+
+class NMSPacketSupport : PacketSupport {
+    companion object {
+        private fun EquipmentSlot.toNMS(): NMSEquipmentSlot {
+            return when (this) {
+                EquipmentSlot.HAND -> NMSEquipmentSlot.MAINHAND
+                EquipmentSlot.OFF_HAND -> NMSEquipmentSlot.OFFHAND
+                EquipmentSlot.FEET -> NMSEquipmentSlot.FEET
+                EquipmentSlot.LEGS -> NMSEquipmentSlot.LEGS
+                EquipmentSlot.CHEST -> NMSEquipmentSlot.CHEST
+                EquipmentSlot.HEAD -> NMSEquipmentSlot.HEAD
+            }
+        }
+    }
+
+    override fun entityMetadata(entity: Entity): NMSPacketContainer {
+        entity as CraftEntity
+
+        val entityId = entity.entityId
+        val entityData = entity.handle.entityData
+
+        // nonDefaultValues가 null일때 ClientboundSetEntityDataPacket.pack(ClientboundSetEntityDataPacket.java:17) 에서 NPE 발생
+        val packet = ClientboundSetEntityDataPacket(entityId, entityData.nonDefaultValues ?: emptyList())
+        return NMSPacketContainer(packet)
+    }
+
+
+    override fun entityEquipment(entityId: Int, equipments: Map<EquipmentSlot, ItemStack>): NMSPacketContainer {
+        val packet = ClientboundSetEquipmentPacket(entityId, equipments.map { entry ->
+            com.mojang.datafixers.util.Pair(entry.key.toNMS(), CraftItemStack.asNMSCopy(entry.value))
+        })
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityTeleport(
+        entityId: Int,
+        x: Double,
+        y: Double,
+        z: Double,
+        yaw: Float,
+        pitch: Float,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeDouble(x)
+        byteBuf.writeDouble(y)
+        byteBuf.writeDouble(z)
+        byteBuf.writeByte(yaw.toProtocolDegrees())
+        byteBuf.writeByte(pitch.toProtocolDegrees())
+        byteBuf.writeBoolean(onGround)
+
+        val packet = ClientboundTeleportEntityPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun relEntityMove(
+        entityId: Int,
+        deltaX: Short,
+        deltaY: Short,
+        deltaZ: Short,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val packet = ClientboundMoveEntityPacket.Pos(entityId, deltaX, deltaY, deltaZ, onGround)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun relEntityMoveLook(
+        entityId: Int,
+        deltaX: Short,
+        deltaY: Short,
+        deltaZ: Short,
+        yaw: Float,
+        pitch: Float,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val packet = ClientboundMoveEntityPacket.PosRot(
+            entityId,
+            deltaX,
+            deltaY,
+            deltaZ,
+            yaw.toProtocolDegrees().toByte(),
+            pitch.toProtocolDegrees().toByte(),
+            onGround
+        )
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityRotation(entityId: Int, yaw: Float, pitch: Float, onGround: Boolean): PacketContainer {
+        return NMSPacketContainer(
+            ClientboundMoveEntityPacket.Rot(
+                entityId,
+                yaw.toProtocolDegrees().toByte(),
+                pitch.toProtocolDegrees().toByte(),
+                onGround
+            )
+        )
+    }
+
+    override fun entityHeadLook(entityId: Int, yaw: Float): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeByte(yaw.toProtocolDegrees())
+
+        return NMSPacketContainer(ClientboundRotateHeadPacket(byteBuf))
+    }
+
+    override fun entityVelocity(entityId: Int, vector: Vector): NMSPacketContainer {
+        val packet = ClientboundSetEntityMotionPacket(entityId, Vec3(vector.x, vector.y, vector.z))
+
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityStatus(
+        entityId: Int,
+        data: Byte
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeInt(entityId)
+        byteBuf.writeByte(data.toInt())
+
+        val packet = ClientboundEntityEventPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityAnimation(
+        entityId: Int,
+        action: Int
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeByte(action)
+
+        return NMSPacketContainer(ClientboundAnimatePacket(byteBuf))
+    }
+
+    override fun hurtAnimation(entityId: Int, yaw: Float): PacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeFloat(yaw)
+
+        val packet = ClientboundHurtAnimationPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun mount(
+        entityId: Int,
+        mountEntityIds: IntArray
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeVarIntArray(mountEntityIds)
+
+        val packet = ClientboundSetPassengersPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun takeItem(
+        entityId: Int,
+        collectorId: Int,
+        stackAmount: Int
+    ): NMSPacketContainer {
+        val packet = ClientboundTakeItemEntityPacket(entityId, collectorId, stackAmount)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun removeEntity(
+        entityId: Int
+    ): NMSPacketContainer {
+        val packet = ClientboundRemoveEntitiesPacket(entityId)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun removeEntities(vararg entityIds: Int): PacketContainer {
+        return NMSPacketContainer(ClientboundRemoveEntitiesPacket(IntArrayList((entityIds))))
+    }
+
+    override fun containerSetSlot(containerId: Int, stateId: Int, slot: Int, item: ItemStack?): NMSPacketContainer {
+        return NMSPacketContainer(
+            ClientboundContainerSetSlotPacket(
+                containerId,
+                stateId,
+                slot,
+                CraftItemStack.asNMSCopy(item)
+            )
+        )
+    }
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun playerInfoAction(action: PlayerInfoAction, player: Player): PacketContainer {
+        if (action == PlayerInfoAction.REMOVE) {
+            return NMSPacketContainer(ClientboundPlayerInfoRemovePacket(listOf(player.uniqueId)))
+        }
+
+        when (action) {
+            PlayerInfoAction.ADD -> ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER
+            PlayerInfoAction.GAME_MODE -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE
+            PlayerInfoAction.LATENCY -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LATENCY
+            PlayerInfoAction.DISPLAY_NAME -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME
+            else -> throw IllegalArgumentException("impossible")
+        }.let { nmsAction ->
+            return NMSPacketContainer(ClientboundPlayerInfoUpdatePacket(nmsAction, (player as CraftPlayer).handle))
+        }
+    }
+
+    override fun playerInfoUpdate(action: PlayerInfoUpdateAction, player: Player): PacketContainer {
+        return when (action) {
+            PlayerInfoUpdateAction.ADD_PLAYER -> ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER
+            PlayerInfoUpdateAction.INITIALIZE_CHAT -> ClientboundPlayerInfoUpdatePacket.Action.INITIALIZE_CHAT
+            PlayerInfoUpdateAction.UPDATE_GAME_MODE -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE
+            PlayerInfoUpdateAction.UPDATE_LISTED -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED
+            PlayerInfoUpdateAction.UPDATE_LATENCY -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LATENCY
+            PlayerInfoUpdateAction.UPDATE_DISPLAY_NAME -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME
+        }.let { nmsAction ->
+            NMSPacketContainer(ClientboundPlayerInfoUpdatePacket(nmsAction, (player as CraftPlayer).handle))
+        }
+    }
+
+    override fun playerInfoRemove(list: List<UUID>): PacketContainer {
+        return NMSPacketContainer(ClientboundPlayerInfoRemovePacket(list))
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/fake/NMSEntityTypes.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/fake/NMSEntityTypes.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_4.fake
+
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.entity.EntityType
+import org.bukkit.Bukkit
+import org.bukkit.craftbukkit.v1_20_R3.CraftServer
+import org.bukkit.entity.Entity as BukkitEntity
+
+/**
+ * @author Nemo
+ */
+internal object NMSEntityTypes {
+    private val ENTITIES = HashMap<Class<out BukkitEntity>, EntityType<*>>()
+
+    init {
+        val server: MinecraftServer = (Bukkit.getServer() as CraftServer).server
+        val level = server.allLevels.first()
+
+        BuiltInRegistries.ENTITY_TYPE.forEach { type ->
+            type.create(level)?.let { entity ->
+                val bukkitClass = entity.bukkitEntity.javaClass
+                val interfaces = bukkitClass.interfaces
+
+                ENTITIES[bukkitClass.asSubclass(BukkitEntity::class.java)] = type
+
+                for (i in interfaces) {
+                    if (BukkitEntity::class.java.isAssignableFrom(i)) {
+                        ENTITIES[i.asSubclass(BukkitEntity::class.java)] = type
+                    }
+                }
+            }
+        }
+    }
+
+    @JvmStatic
+    fun findType(bukkitClass: Class<out BukkitEntity>): EntityType<*> {
+        return ENTITIES[bukkitClass] ?: error("Unknown entity type $bukkitClass")
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/fake/NMSFakeSupport.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/fake/NMSFakeSupport.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_4.fake
+
+import com.destroystokyo.paper.profile.ProfileProperty
+import com.mojang.authlib.GameProfile
+import com.mojang.authlib.properties.Property
+import io.github.monun.tap.fake.FakeSkinParts
+import io.github.monun.tap.fake.FakeSupport
+import io.github.monun.tap.v1_20_4.network.NMSEmptyConnection
+import io.github.monun.tap.v1_20_4.network.NMSEmptyPacketListener
+import io.github.monun.tap.v1_20_4.protocol.NMSPacketContainer
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
+import net.minecraft.server.level.ClientInformation
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.network.CommonListenerCookie
+import net.minecraft.world.entity.item.FallingBlockEntity
+import net.minecraft.world.entity.item.ItemEntity
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.World
+import org.bukkit.block.data.BlockData
+import org.bukkit.craftbukkit.v1_20_R3.CraftServer
+import org.bukkit.craftbukkit.v1_20_R3.CraftWorld
+import org.bukkit.craftbukkit.v1_20_R3.block.data.CraftBlockData
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
+import org.bukkit.entity.*
+import org.bukkit.inventory.ItemStack
+import java.util.*
+
+/**
+ * @author Nemo
+ */
+class NMSFakeSupport : FakeSupport {
+
+    override fun getNetworkId(entity: Entity): Int {
+        entity as CraftEntity
+
+        return BuiltInRegistries.ENTITY_TYPE.getId(entity.handle.type)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Entity> createEntity(entityClass: Class<out Entity>, world: World): T {
+        return NMSEntityTypes.findType(entityClass).run {
+            val nmsWorld = (world as CraftWorld).handle
+            this.create(nmsWorld)?.bukkitEntity as T
+        }
+    }
+
+    override fun isInvisible(entity: Entity): Boolean {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        return nmsEntity.isInvisible
+    }
+
+    override fun setInvisible(entity: Entity, invisible: Boolean) {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        nmsEntity.isInvisible = invisible
+    }
+
+    private val nmsPoses = net.minecraft.world.entity.Pose.values()
+    override fun setPose(entity: Entity, pose: Pose) {
+        (entity as CraftEntity).handle.pose = nmsPoses[pose.ordinal]
+    }
+
+    override fun setLocation(
+        entity: Entity,
+        loc: Location
+    ) {
+        entity as CraftEntity
+        val nmsEntity = entity.handle
+
+        loc.run {
+            nmsEntity.setLevel((world as CraftWorld).handle)
+            nmsEntity.moveTo(x, y, z, yaw, pitch)
+        }
+    }
+
+    @Deprecated("Unimplemented due to inner offset method change", ReplaceWith(""))
+    override fun getMountedYOffset(entity: Entity): Double {
+        return 0.0
+    }
+
+    @Deprecated("Unimplemented due to inner offset method change", ReplaceWith(""))
+    override fun getYOffset(entity: Entity): Double {
+        return 0.0
+    }
+
+    /* Modified */
+    override fun createSpawnPacket(entity: Entity): Array<NMSPacketContainer> {
+        val packets = arrayListOf<NMSPacketContainer>()
+        entity as CraftEntity
+        if (entity is Player) {
+            packets.add(
+                NMSPacketContainer(
+                    ClientboundPlayerInfoUpdatePacket(
+                        ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER,
+                        entity.handle as ServerPlayer
+                    )
+                )
+            )
+        }
+        packets.add(NMSPacketContainer(entity.handle.addEntityPacket))
+
+        return packets.toTypedArray()
+    }
+
+    override fun createFallingBlock(blockData: BlockData): FallingBlock {
+        val entity =
+            FallingBlockEntity(
+                (Bukkit.getWorlds().first() as CraftWorld).handle,
+                0.0,
+                0.0,
+                0.0,
+                (blockData as CraftBlockData).state
+            )
+
+        return entity.bukkitEntity as FallingBlock
+    }
+
+    override fun createItemEntity(item: ItemStack): Item {
+        val entity =
+            ItemEntity(
+                (Bukkit.getWorlds().first() as CraftWorld).handle,
+                0.0,
+                0.0,
+                0.0,
+                CraftItemStack.asNMSCopy(item)
+            )
+        entity.setNeverPickUp()
+
+        return entity.bukkitEntity as Item
+    }
+
+    override fun createPlayerEntity(
+        name: String,
+        profileProperties: Set<ProfileProperty>,
+        skinParts: FakeSkinParts,
+        uniqueId: UUID
+    ): Player {
+        val server = (Bukkit.getServer() as CraftServer).handle.server
+        val gameProfile = GameProfile(uniqueId, name).apply {
+            for (property in profileProperties) {
+                val propertyName = property.name
+                properties.put(propertyName, Property(propertyName, property.value, property.signature))
+            }
+        }
+        val clientInfo = ClientInformation.createDefault()
+
+        val player = ServerPlayer(
+            server,
+            (Bukkit.getWorlds().first() as CraftWorld).handle,
+            gameProfile,
+            clientInfo
+        )
+
+
+        player.connection =
+            NMSEmptyPacketListener(server, NMSEmptyConnection, player, CommonListenerCookie(gameProfile, 0, clientInfo))
+
+        player.entityData.set(
+            ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION,
+            skinParts.raw.toByte()
+        )
+
+        return player.bukkitEntity
+    }
+
+    override fun setSkinParts(player: Player, raw: Int) {
+        (player as CraftPlayer).handle.apply {
+            entityData.set(ServerPlayer.DATA_PLAYER_MODE_CUSTOMISATION, raw.toByte())
+        }
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/item/NMSItemSupport.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/item/NMSItemSupport.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_4.item
+
+import io.github.monun.tap.item.ItemSupport
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.item.ItemStack
+import org.bukkit.craftbukkit.v1_20_R3.CraftEquipmentSlot
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftInventoryPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack as BukkitItemStack
+import org.bukkit.inventory.PlayerInventory as BukkitPlayerInventory
+
+class NMSItemSupport : ItemSupport {
+    override fun saveToJsonString(item: BukkitItemStack): String {
+        val nmsItem = CraftItemStack.asNMSCopy(item)
+        return nmsItem.save(CompoundTag()).toString()
+    }
+
+    override fun damageArmor(playerInventory: BukkitPlayerInventory, attackDamage: Double) {
+        val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
+        
+        nmsInventory.hurtArmor(
+            nmsInventory.player.damageSources().lava(),
+            attackDamage.toFloat(),
+            Inventory.ALL_ARMOR_SLOTS
+        )
+    }
+
+    override fun damageSlot(playerInventory: BukkitPlayerInventory, slot: EquipmentSlot, damage: Int) {
+        val nmsInventory = (playerInventory as CraftInventoryPlayer).inventory
+        val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+        val nmsItem = nmsInventory.getItem(slot)
+
+        if (!nmsItem.isEmpty) {
+            nmsItem.hurtAndBreak(damage, (playerInventory.holder as CraftPlayer).handle) { player ->
+                player.broadcastBreakEvent(nmsSlot)
+            }
+        }
+    }
+}
+
+internal fun Inventory.getItem(slot: EquipmentSlot): ItemStack {
+    return when (slot) {
+        EquipmentSlot.HAND -> getSelected()
+        EquipmentSlot.OFF_HAND -> offhand[0]
+        EquipmentSlot.FEET -> armorContents[0]
+        EquipmentSlot.LEGS -> armorContents[1]
+        EquipmentSlot.CHEST -> armorContents[2]
+        EquipmentSlot.HEAD -> armorContents[3]
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/network/NMSEmptyChannel.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/network/NMSEmptyChannel.kt
@@ -1,0 +1,60 @@
+package io.github.monun.tap.v1_20_4.network
+
+import io.netty.channel.*
+import java.net.SocketAddress
+
+class NMSEmptyChannel(parent: Channel?) : AbstractChannel(parent) {
+    private val config: ChannelConfig = DefaultChannelConfig(this)
+    override fun config(): ChannelConfig {
+        config.setAutoRead(true)
+        return config
+    }
+
+    @Throws(Exception::class)
+    override fun doBeginRead() {
+    }
+
+    @Throws(Exception::class)
+    override fun doBind(arg0: SocketAddress) {
+    }
+
+    @Throws(Exception::class)
+    override fun doClose() {
+    }
+
+    @Throws(Exception::class)
+    override fun doDisconnect() {
+    }
+
+    @Throws(Exception::class)
+    override fun doWrite(arg0: ChannelOutboundBuffer) {
+    }
+
+    override fun isActive(): Boolean {
+        return false
+    }
+
+    override fun isCompatible(arg0: EventLoop): Boolean {
+        return false
+    }
+
+    override fun isOpen(): Boolean {
+        return false
+    }
+
+    override fun localAddress0(): SocketAddress? {
+        return null
+    }
+
+    override fun metadata(): ChannelMetadata {
+        return ChannelMetadata(true)
+    }
+
+    override fun newUnsafe(): AbstractUnsafe? {
+        return null
+    }
+
+    override fun remoteAddress0(): SocketAddress? {
+        return null
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/network/NMSEmptyConnection.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/network/NMSEmptyConnection.kt
@@ -1,0 +1,40 @@
+package io.github.monun.tap.v1_20_4.network
+
+import net.minecraft.network.Connection
+import net.minecraft.network.PacketListener
+import net.minecraft.network.PacketSendListener
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.PacketFlow
+import java.lang.invoke.MethodHandles
+import java.net.SocketAddress
+
+object NMSEmptyConnection : Connection(PacketFlow.CLIENTBOUND) {
+    init {
+        channel = NMSEmptyChannel(null)
+        address = object : SocketAddress() {
+            private val serialVersionUID = 8207338859896320185L
+        }
+    }
+
+    override fun isConnected(): Boolean {
+        return true
+    }
+
+    override fun send(packet: Packet<*>, genericfuturelistener: PacketSendListener?) {}
+    override fun setListener(pl: PacketListener) {
+        try {
+            val lookup = MethodHandles.lookup()
+
+            val connectionJavaClass = Connection::class.java
+            val connectionPacketListener = connectionJavaClass.getDeclaredField("q")
+            val connectionDisconnectListener = connectionJavaClass.getDeclaredField("p")
+            connectionPacketListener.isAccessible = true
+            connectionDisconnectListener.isAccessible = true
+
+            lookup.unreflectSetter(connectionPacketListener).invoke(this, pl)
+            lookup.unreflectSetter(connectionDisconnectListener).invoke(this, null)
+        } catch (e: Throwable) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/network/NMSEmptyPacketListener.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/network/NMSEmptyPacketListener.kt
@@ -1,0 +1,19 @@
+package io.github.monun.tap.v1_20_4.network
+
+import net.minecraft.network.Connection
+import net.minecraft.network.protocol.Packet
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.level.ServerPlayer
+import net.minecraft.server.network.CommonListenerCookie
+import net.minecraft.server.network.ServerGamePacketListenerImpl
+
+
+class NMSEmptyPacketListener(
+    minecraftServer: MinecraftServer,
+    networkManager: Connection,
+    entityPlayer: ServerPlayer,
+    clc: CommonListenerCookie
+) :
+    ServerGamePacketListenerImpl(minecraftServer, networkManager, entityPlayer, clc) {
+    override fun send(packet: Packet<*>) {}
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/protocol/NMSPacketContainer.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/protocol/NMSPacketContainer.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_4.protocol
+
+import io.github.monun.tap.protocol.PacketContainer
+import net.minecraft.network.protocol.Packet
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.entity.Player
+
+
+class NMSPacketContainer(private val packet: Packet<*>) : PacketContainer {
+    override fun sendTo(player: Player) {
+        (player as CraftPlayer).handle.connection.send(packet, null)
+    }
+}

--- a/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/protocol/NMSPacketSupport.kt
+++ b/tap-dongle/v1.20.4/src/main/kotlin/io/github/monun/tap/v1_20_4/protocol/NMSPacketSupport.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2023 Monun
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package io.github.monun.tap.v1_20_4.protocol
+
+import io.github.monun.tap.protocol.*
+import io.netty.buffer.Unpooled
+import it.unimi.dsi.fastutil.ints.IntArrayList
+import net.minecraft.network.FriendlyByteBuf
+import net.minecraft.network.protocol.game.*
+import net.minecraft.world.phys.Vec3
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftEntity
+import org.bukkit.craftbukkit.v1_20_R3.entity.CraftPlayer
+import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+import org.bukkit.util.Vector
+import java.util.*
+import net.minecraft.world.entity.EquipmentSlot as NMSEquipmentSlot
+
+class NMSPacketSupport : PacketSupport {
+    companion object {
+        private fun EquipmentSlot.toNMS(): NMSEquipmentSlot {
+            return when (this) {
+                EquipmentSlot.HAND -> NMSEquipmentSlot.MAINHAND
+                EquipmentSlot.OFF_HAND -> NMSEquipmentSlot.OFFHAND
+                EquipmentSlot.FEET -> NMSEquipmentSlot.FEET
+                EquipmentSlot.LEGS -> NMSEquipmentSlot.LEGS
+                EquipmentSlot.CHEST -> NMSEquipmentSlot.CHEST
+                EquipmentSlot.HEAD -> NMSEquipmentSlot.HEAD
+            }
+        }
+    }
+
+    override fun entityMetadata(entity: Entity): NMSPacketContainer {
+        entity as CraftEntity
+
+        val entityId = entity.entityId
+        val entityData = entity.handle.entityData
+
+        // nonDefaultValues가 null일때 ClientboundSetEntityDataPacket.pack(ClientboundSetEntityDataPacket.java:17) 에서 NPE 발생
+        val packet = ClientboundSetEntityDataPacket(entityId, entityData.nonDefaultValues ?: emptyList())
+        return NMSPacketContainer(packet)
+    }
+
+
+    override fun entityEquipment(entityId: Int, equipments: Map<EquipmentSlot, ItemStack>): NMSPacketContainer {
+        val packet = ClientboundSetEquipmentPacket(entityId, equipments.map { entry ->
+            com.mojang.datafixers.util.Pair(entry.key.toNMS(), CraftItemStack.asNMSCopy(entry.value))
+        })
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityTeleport(
+        entityId: Int,
+        x: Double,
+        y: Double,
+        z: Double,
+        yaw: Float,
+        pitch: Float,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeDouble(x)
+        byteBuf.writeDouble(y)
+        byteBuf.writeDouble(z)
+        byteBuf.writeByte(yaw.toProtocolDegrees())
+        byteBuf.writeByte(pitch.toProtocolDegrees())
+        byteBuf.writeBoolean(onGround)
+
+        val packet = ClientboundTeleportEntityPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun relEntityMove(
+        entityId: Int,
+        deltaX: Short,
+        deltaY: Short,
+        deltaZ: Short,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val packet = ClientboundMoveEntityPacket.Pos(entityId, deltaX, deltaY, deltaZ, onGround)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun relEntityMoveLook(
+        entityId: Int,
+        deltaX: Short,
+        deltaY: Short,
+        deltaZ: Short,
+        yaw: Float,
+        pitch: Float,
+        onGround: Boolean
+    ): NMSPacketContainer {
+        val packet = ClientboundMoveEntityPacket.PosRot(
+            entityId,
+            deltaX,
+            deltaY,
+            deltaZ,
+            yaw.toProtocolDegrees().toByte(),
+            pitch.toProtocolDegrees().toByte(),
+            onGround
+        )
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityRotation(entityId: Int, yaw: Float, pitch: Float, onGround: Boolean): PacketContainer {
+        return NMSPacketContainer(
+            ClientboundMoveEntityPacket.Rot(
+                entityId,
+                yaw.toProtocolDegrees().toByte(),
+                pitch.toProtocolDegrees().toByte(),
+                onGround
+            )
+        )
+    }
+
+    override fun entityHeadLook(entityId: Int, yaw: Float): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeByte(yaw.toProtocolDegrees())
+
+        return NMSPacketContainer(ClientboundRotateHeadPacket(byteBuf))
+    }
+
+    override fun entityVelocity(entityId: Int, vector: Vector): NMSPacketContainer {
+        val packet = ClientboundSetEntityMotionPacket(entityId, Vec3(vector.x, vector.y, vector.z))
+
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityStatus(
+        entityId: Int,
+        data: Byte
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeInt(entityId)
+        byteBuf.writeByte(data.toInt())
+
+        val packet = ClientboundEntityEventPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun entityAnimation(
+        entityId: Int,
+        action: Int
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeByte(action)
+
+        return NMSPacketContainer(ClientboundAnimatePacket(byteBuf))
+    }
+
+    override fun hurtAnimation(entityId: Int, yaw: Float): PacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeFloat(yaw)
+
+        val packet = ClientboundHurtAnimationPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun mount(
+        entityId: Int,
+        mountEntityIds: IntArray
+    ): NMSPacketContainer {
+        val byteBuf = FriendlyByteBuf(Unpooled.buffer())
+
+        byteBuf.writeVarInt(entityId)
+        byteBuf.writeVarIntArray(mountEntityIds)
+
+        val packet = ClientboundSetPassengersPacket(byteBuf)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun takeItem(
+        entityId: Int,
+        collectorId: Int,
+        stackAmount: Int
+    ): NMSPacketContainer {
+        val packet = ClientboundTakeItemEntityPacket(entityId, collectorId, stackAmount)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun removeEntity(
+        entityId: Int
+    ): NMSPacketContainer {
+        val packet = ClientboundRemoveEntitiesPacket(entityId)
+        return NMSPacketContainer(packet)
+    }
+
+    override fun removeEntities(vararg entityIds: Int): PacketContainer {
+        return NMSPacketContainer(ClientboundRemoveEntitiesPacket(IntArrayList((entityIds))))
+    }
+
+    override fun containerSetSlot(containerId: Int, stateId: Int, slot: Int, item: ItemStack?): NMSPacketContainer {
+        return NMSPacketContainer(
+            ClientboundContainerSetSlotPacket(
+                containerId,
+                stateId,
+                slot,
+                CraftItemStack.asNMSCopy(item)
+            )
+        )
+    }
+
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION")
+    override fun playerInfoAction(action: PlayerInfoAction, player: Player): PacketContainer {
+        if (action == PlayerInfoAction.REMOVE) {
+            return NMSPacketContainer(ClientboundPlayerInfoRemovePacket(listOf(player.uniqueId)))
+        }
+
+        when (action) {
+            PlayerInfoAction.ADD -> ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER
+            PlayerInfoAction.GAME_MODE -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE
+            PlayerInfoAction.LATENCY -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LATENCY
+            PlayerInfoAction.DISPLAY_NAME -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME
+            else -> throw IllegalArgumentException("impossible")
+        }.let { nmsAction ->
+            return NMSPacketContainer(ClientboundPlayerInfoUpdatePacket(nmsAction, (player as CraftPlayer).handle))
+        }
+    }
+
+    override fun playerInfoUpdate(action: PlayerInfoUpdateAction, player: Player): PacketContainer {
+        return when (action) {
+            PlayerInfoUpdateAction.ADD_PLAYER -> ClientboundPlayerInfoUpdatePacket.Action.ADD_PLAYER
+            PlayerInfoUpdateAction.INITIALIZE_CHAT -> ClientboundPlayerInfoUpdatePacket.Action.INITIALIZE_CHAT
+            PlayerInfoUpdateAction.UPDATE_GAME_MODE -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_GAME_MODE
+            PlayerInfoUpdateAction.UPDATE_LISTED -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LISTED
+            PlayerInfoUpdateAction.UPDATE_LATENCY -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_LATENCY
+            PlayerInfoUpdateAction.UPDATE_DISPLAY_NAME -> ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME
+        }.let { nmsAction ->
+            NMSPacketContainer(ClientboundPlayerInfoUpdatePacket(nmsAction, (player as CraftPlayer).handle))
+        }
+    }
+
+    override fun playerInfoRemove(list: List<UUID>): PacketContainer {
+        return NMSPacketContainer(ClientboundPlayerInfoRemovePacket(list))
+    }
+}


### PR DESCRIPTION
# Support 1.20.2 ~ 1.20.4 without riding offset methods

## 변경사항:
1. 1.20.2부터 FakePlayer를 생성하는 과정에서 비어있는 connection을 새로 생성합니다. 이는 NMS 내부에서 변경사항으로 발생한 조치이며 작업 과정에서 Reflection을 사용하게 되었습니다.
EmptyConnection을 생성하기 위한 코드는 Citizens 플러그인의 코드에서 가져왔습니다.

2. Paperweight 버전을 1.5.11로 올렸습니다.

3. 5.0.0으로 릴리즈 버전을 업데이트했습니다.

## 안내사항

1.20.2부터 변경된 riding offset 관련 메서드를 Tap 내에서 구현하기에 (주관적인 기준으로) 많은 어려움이 있으며 Tap에서 제공하는 riding offset 관련 API를 제거하기에는 모든 버전이 영향을 받는 구조이므로 1.20.2 ~ 1.20.4에서는 해당 메서드들이 Deprecated 처리되고, 강제로 0.0을 반환하도록 설정했습니다.

이는 **어디까지나 임시적인 조치**이며, 이후 구조는 직접 해결해주셔야 할 것 같습니다. (죄송합니다...)